### PR TITLE
Add support for WMS layers, non-base tile layers, deactivated layers and...

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/LLayerGroup.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LLayerGroup.java
@@ -14,9 +14,15 @@ public class LLayerGroup extends AbstractComponentContainer {
 
     private List<Component> components = new ArrayList<Component>();
     private final String name;
+    private Boolean active;
+
+    public LLayerGroup(String name, Boolean active) {
+        this.name = name;
+        this.active = active;
+    }
 
     public LLayerGroup(String name) {
-        this.name = name;
+        this(name, true);
     }
 
     public LLayerGroup() {
@@ -50,6 +56,7 @@ public class LLayerGroup extends AbstractComponentContainer {
     public void beforeClientResponse(boolean initial) {
         super.beforeClientResponse(initial);
         getState().name = name;
+        getState().active = active;
     }
 
     @Override
@@ -67,4 +74,8 @@ public class LLayerGroup extends AbstractComponentContainer {
         return components.iterator();
     }
 
+    public void setActive(Boolean active) {
+		this.active = active;
+		getState().active = active;
+    }
 }

--- a/src/main/java/org/vaadin/addon/leaflet/LTileLayer.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LTileLayer.java
@@ -1,0 +1,79 @@
+package org.vaadin.addon.leaflet;
+
+import org.vaadin.addon.leaflet.client.vaadin.LeafletTileLayerState;
+
+public class LTileLayer extends LeafletLayer {
+
+	public LTileLayer(String name) {
+		super(name);
+	}
+
+	@Override
+	protected LeafletTileLayerState getState() {
+		return (LeafletTileLayerState) super.getState();
+	}
+
+	public String getUrl() {
+		return getState().url;
+	}
+
+	public void setUrl(String url) {
+		getState().url = url;
+	}
+
+	public String getName() {
+		return getState().name;
+	}
+
+	public void setName(String name) {
+		getState().name = name;
+	}
+
+	public String getAttributionString() {
+		return getState().attributionString;
+	}
+
+	public void setAttributionString(String attributionString) {
+		getState().attributionString = attributionString;
+	}
+
+	public Boolean getDetectRetina() {
+		return getState().detectRetina;
+	}
+
+	public void setDetectRetina(Boolean detectRetina) {
+		getState().detectRetina = detectRetina;
+	}
+
+	public Boolean getTms() {
+		return getState().tms;
+	}
+
+	public void setTms(Boolean tms) {
+		getState().tms = tms;
+	}
+
+	public Integer getMaxZoom() {
+		return getState().maxZoom;
+	}
+
+	public void setMaxZoom(Integer maxZoom) {
+		getState().maxZoom = maxZoom;
+	}
+
+	public String[] getSubDomains() {
+		return getState().subDomains;
+	}
+
+	public void setSubDomains(String[] subDomains) {
+		getState().subDomains = subDomains;
+	}
+
+	public Double getOpacity() {
+		return getState().opacity;
+	}
+
+	public void setOpacity(Double opacity) {
+		getState().opacity = opacity;
+	}
+}

--- a/src/main/java/org/vaadin/addon/leaflet/LTileLayerWms.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LTileLayerWms.java
@@ -1,0 +1,55 @@
+package org.vaadin.addon.leaflet;
+
+import org.vaadin.addon.leaflet.client.vaadin.LeafletTileLayerWmsState;
+
+public class LTileLayerWms extends LTileLayer {
+
+	public LTileLayerWms(String name) {
+		super(name);
+	}
+
+	@Override
+	protected LeafletTileLayerWmsState getState() {
+		return (LeafletTileLayerWmsState) super.getState();
+	}
+
+	public String getLayers() {
+		return getState().layers;
+	}
+
+	public void setLayers(String layers) {
+		getState().layers = layers;
+	}
+
+	public String getStyles() {
+		return getState().layerStyles;
+	}
+
+	public void setStyles(String styles) {
+		getState().layerStyles = styles;
+	}
+
+	public String getFormat() {
+		return getState().format;
+	}
+
+	public void setFormat(String format) {
+		getState().format = format;
+	}
+
+	public Boolean getTransparent() {
+		return getState().transparent;
+	}
+
+	public void setTransparent(Boolean transparent) {
+		getState().transparent = transparent;
+	}
+
+	public String getVersion() {
+		return getState().version;
+	}
+
+	public void setVersion(String version) {
+		getState().version = version;
+	}
+}

--- a/src/main/java/org/vaadin/addon/leaflet/LeafletLayer.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LeafletLayer.java
@@ -9,11 +9,17 @@ import com.vaadin.ui.AbstractComponent;
 public abstract class LeafletLayer extends AbstractComponent {
 
     private String name;
+    private Boolean active;
 
     public LeafletLayer(String name) {
+		this(name, true);
+    }
+
+    public LeafletLayer(String name, Boolean active) {
         // the idea of accessing the state from constructor may not be
         // a good idea(?)
         this.name = name;
+        this.active = active;
         registerRpc(new ClickServerRpc() {
             @Override
             public void onClick(Point p) {
@@ -26,6 +32,7 @@ public abstract class LeafletLayer extends AbstractComponent {
     public void beforeClientResponse(boolean initial) {
         super.beforeClientResponse(initial);
         getState().name = name;
+        getState().active = active;
     }
 
     @Override
@@ -41,5 +48,10 @@ public abstract class LeafletLayer extends AbstractComponent {
     public void removeMarkerClickListener(LeafletClickListener listener) {
         removeListener(LeafletClickEvent.class, listener,
                 LeafletClickListener.METHOD);
+    }
+
+    public void setActive(Boolean active) {
+		this.active = active;
+		getState().active = active;
     }
 }

--- a/src/main/java/org/vaadin/addon/leaflet/client/vaadin/AbstractLeafletComponentState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/vaadin/AbstractLeafletComponentState.java
@@ -8,4 +8,5 @@ public class AbstractLeafletComponentState extends AbstractComponentState {
     // Used as caption for the control
     public String name;
 
+    public Boolean active;
 }

--- a/src/main/java/org/vaadin/addon/leaflet/client/vaadin/AbstractLeafletLayerConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/vaadin/AbstractLeafletLayerConnector.java
@@ -39,7 +39,9 @@ public abstract class AbstractLeafletLayerConnector<T> extends
         if (parent instanceof LeafletMapConnector) {
             Map map = ((LeafletMapConnector) parent).getMap();
             // Something is wrong if map is null here
-            map.addLayer(layer);
+            if(getState().active != null && getState().active) {
+				map.addLayer(layer);
+			}
             leafletParent = map;
         } else {
             LayerGroup layerGroup = (LayerGroup) (((LeafletLayerGroupConnector) parent)

--- a/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletMapConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletMapConnector.java
@@ -33,6 +33,7 @@ import org.discotools.gwt.leaflet.client.events.handler.EventHandlerManager;
 import org.discotools.gwt.leaflet.client.jsobject.JSObject;
 import org.discotools.gwt.leaflet.client.layers.ILayer;
 import org.discotools.gwt.leaflet.client.layers.raster.TileLayer;
+import org.discotools.gwt.leaflet.client.layers.raster.WmsLayer;
 import org.discotools.gwt.leaflet.client.map.Map;
 import org.discotools.gwt.leaflet.client.map.MapOptions;
 import org.discotools.gwt.leaflet.client.types.LatLng;
@@ -298,9 +299,35 @@ public class LeafletMapConnector extends AbstractHasComponentsConnector {
 						&& baseLayer.getTms()) {
 					tileOptions.setProperty("tms", true);
 				}
-				TileLayer layer = new TileLayer(baseLayer.getUrl(), tileOptions);
-				map.addLayer(layer);
-				layers.put(baseLayer, layer);
+				if (baseLayer.getOpacity() != null) {
+					tileOptions.setProperty("opacity", baseLayer.getOpacity());
+				}
+
+				if(baseLayer.getWms() != null &&  baseLayer.getWms() == true) {
+					if(baseLayer.getLayers() != null) {
+						tileOptions.setProperty("layers", baseLayer.getLayers());
+					}
+					if(baseLayer.getStyles() != null) {
+						tileOptions.setProperty("styles", baseLayer.getStyles());
+					}
+					if(baseLayer.getFormat() != null) {
+						tileOptions.setProperty("format", baseLayer.getFormat());
+					}
+					if(baseLayer.getTransparent() != null
+						&& baseLayer.getTransparent()) {
+						tileOptions.setProperty("transparent", true);
+					}
+					if(baseLayer.getVersion() != null) {
+						tileOptions.setProperty("version", baseLayer.getVersion());
+					}
+					WmsLayer layer = new WmsLayer(baseLayer.getUrl(), tileOptions);
+					map.addLayer(layer);
+					layers.put(baseLayer, layer);
+				} else {
+					TileLayer layer = new TileLayer(baseLayer.getUrl(), tileOptions);
+					map.addLayer(layer);
+					layers.put(baseLayer, layer);
+				}
 			}
 		}
 	}

--- a/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletTileLayerConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletTileLayerConnector.java
@@ -1,0 +1,63 @@
+package org.vaadin.addon.leaflet.client.vaadin;
+
+import org.discotools.gwt.leaflet.client.Options;
+import org.discotools.gwt.leaflet.client.jsobject.JSObject;
+import org.discotools.gwt.leaflet.client.layers.ILayer;
+import org.discotools.gwt.leaflet.client.layers.raster.TileLayer;
+
+import com.google.gwt.core.client.JsArrayString;
+import com.vaadin.shared.ui.Connect;
+
+@Connect(org.vaadin.addon.leaflet.LTileLayer.class)
+public class LeafletTileLayerConnector extends
+		AbstractLeafletLayerConnector<Options> {
+
+	protected ILayer layer;
+
+	@Override
+	public LeafletTileLayerState getState() {
+		return (LeafletTileLayerState) super.getState();
+	}
+
+	@Override
+	protected Options createOptions() {
+		Options o = new Options();
+		LeafletTileLayerState s = getState();
+		o.setProperty("attribution", s.url);
+		if (s.detectRetina != null && s.detectRetina) {
+			o.setProperty("detectRetina", true);
+		}
+		if (s.subDomains != null) {
+			JsArrayString domain = JsArrayString.createArray().cast();
+			for (String a : s.subDomains) {
+				domain.push(a);
+			}
+			o.setProperty("subdomains", (JSObject) domain.cast());
+		}
+		if (s.maxZoom != null) {
+			o.setProperty("maxZoom", s.maxZoom);
+		}
+		if (s.tms != null && s.tms) {
+			o.setProperty("tms", true);
+		}
+		if (s.opacity != null) {
+			o.setProperty("opacity", s.opacity);
+		}
+		return o;
+	}
+
+	@Override
+	protected void update() {
+		if (layer != null) {
+			removeLayerFromParent();
+		}
+		Options o = createOptions();
+		layer = new TileLayer(getState().url, o);
+		addToParent(layer);
+	}
+
+	@Override
+	public ILayer getLayer() {
+		return layer;
+	}
+}

--- a/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletTileLayerState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletTileLayerState.java
@@ -1,0 +1,12 @@
+package org.vaadin.addon.leaflet.client.vaadin;
+
+public class LeafletTileLayerState extends AbstractLeafletComponentState {
+
+	public String url;
+	public String attributionString;
+	public Boolean detectRetina;
+	public Boolean tms;
+	public Integer maxZoom;
+	public String[] subDomains;
+	public Double opacity;
+}

--- a/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletTileLayerWmsConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletTileLayerWmsConnector.java
@@ -1,0 +1,47 @@
+package org.vaadin.addon.leaflet.client.vaadin;
+
+import org.discotools.gwt.leaflet.client.Options;
+import org.discotools.gwt.leaflet.client.layers.raster.WmsLayer;
+
+import com.vaadin.shared.ui.Connect;
+
+@Connect(org.vaadin.addon.leaflet.LTileLayerWms.class)
+public class LeafletTileLayerWmsConnector extends LeafletTileLayerConnector {
+
+	@Override
+	public LeafletTileLayerWmsState getState() {
+		return (LeafletTileLayerWmsState) super.getState();
+	}
+
+	@Override
+	protected Options createOptions() {
+		Options o = super.createOptions();
+		LeafletTileLayerWmsState s = getState();
+		if (s.layers != null) {
+			o.setProperty("layers", s.layers);
+		}
+		if (s.layerStyles != null) {
+			o.setProperty("styles", s.layerStyles);
+		}
+		if (s.format != null) {
+			o.setProperty("format", s.format);
+		}
+		if (s.transparent != null && s.transparent) {
+			o.setProperty("transparent", true);
+		}
+		if (s.version != null) {
+			o.setProperty("version", s.version);
+		}
+		return o;
+	}
+
+	@Override
+	protected void update() {
+		if (layer != null) {
+			removeLayerFromParent();
+		}
+		Options o = createOptions();
+		layer = new WmsLayer(getState().url, o);
+		addToParent(layer);
+	}
+}

--- a/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletTileLayerWmsState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletTileLayerWmsState.java
@@ -1,0 +1,10 @@
+package org.vaadin.addon.leaflet.client.vaadin;
+
+public class LeafletTileLayerWmsState extends LeafletTileLayerState {
+
+	public String layers;
+	public String layerStyles;
+	public String format;
+	public Boolean transparent;
+	public String version;
+}

--- a/src/main/java/org/vaadin/addon/leaflet/shared/BaseLayer.java
+++ b/src/main/java/org/vaadin/addon/leaflet/shared/BaseLayer.java
@@ -12,6 +12,13 @@ public class BaseLayer implements Serializable {
 	private Boolean tms;
 	private Integer maxZoom;
 	private String[] subDomains;
+	private Boolean wms;
+	private String layers;
+	private String styles;
+	private String format;
+	private Boolean transparent;
+	private String version;
+	private Double opacity;
 	
 	public String getUrl() {
 		return url;
@@ -66,4 +73,59 @@ public class BaseLayer implements Serializable {
 		this.tms = tms;
 	}
 
+	public Boolean getWms() {
+		return wms;
+	}
+
+	public void setWms(Boolean wms) {
+		this.wms = wms;
+	}
+
+	public String getLayers() {
+		return layers;
+	}
+
+	public void setLayers(String layers) {
+		this.layers = layers;
+	}
+
+	public String getStyles() {
+		return styles;
+	}
+
+	public void setStyles(String styles) {
+		this.styles = styles;
+	}
+
+	public String getFormat() {
+		return format;
+	}
+
+	public void setFormat(String format) {
+		this.format = format;
+	}
+
+	public Boolean getTransparent() {
+		return transparent;
+	}
+
+	public void setTransparent(Boolean transparent) {
+		this.transparent = transparent;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+
+	public Double getOpacity() {
+		return opacity;
+	}
+
+	public void setOpacity(Double opacity) {
+		this.opacity = opacity;
+	}
 }

--- a/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/LayersTest.java
+++ b/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/LayersTest.java
@@ -1,0 +1,79 @@
+package org.vaadin.addon.leaflet.demoandtestapp;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.vaadin.addon.leaflet.LLayerGroup;
+import org.vaadin.addon.leaflet.LMap;
+import org.vaadin.addon.leaflet.LTileLayerWms;
+import org.vaadin.addon.leaflet.demoandtestapp.util.AbstractTest;
+import org.vaadin.addon.leaflet.shared.BaseLayer;
+import org.vaadin.addon.leaflet.shared.Control;
+
+import com.vaadin.ui.Component;
+
+public class LayersTest extends AbstractTest {
+
+	@Override
+	public String getDescription() {
+		return "Test for various layer features";
+	}
+
+	private LMap leafletMap;
+
+	@Override
+	public Component getTestComponent() {
+		leafletMap = new LMap();
+		leafletMap.setCenter(40.525282, -3.81603);
+		leafletMap.setZoomLevel(11);
+
+		leafletMap.setControls(new ArrayList<Control>(Arrays.asList(Control
+				.values())));
+
+		BaseLayer baseLayerIgn = new BaseLayer();
+		baseLayerIgn.setWms(true);
+		baseLayerIgn.setName("IGN");
+		baseLayerIgn.setUrl("http://www.01.ign.es/wms-inspire/ign-base");
+		baseLayerIgn.setLayers("SombreadoPenBal");
+		baseLayerIgn.setTransparent(false);
+		baseLayerIgn.setFormat("image/jpeg");
+		baseLayerIgn.setOpacity(0.5);
+
+		BaseLayer baseLayerOsm = new BaseLayer();
+		baseLayerOsm.setName("OSM");
+		baseLayerOsm.setUrl("http://{s}.tile.osm.org/{z}/{x}/{y}.png");
+
+		LLayerGroup groupAreas = new LLayerGroup("Populated Areas & Water");
+
+		LTileLayerWms layerWmsAreas = new LTileLayerWms(null);
+		layerWmsAreas.setUrl("http://www.01.ign.es/wms-inspire/ign-base");
+		layerWmsAreas.setLayers("NucleosPob_mayores,LugarInteres");
+		layerWmsAreas.setTransparent(true);
+		layerWmsAreas.setFormat("image/png");
+		layerWmsAreas.setOpacity(0.5);
+		groupAreas.addComponent(layerWmsAreas);
+
+		LTileLayerWms layerWmsWater = new LTileLayerWms(null);
+		layerWmsWater.setUrl("http://www.01.ign.es/wms-inspire/ign-base");
+		layerWmsWater.setLayers("HY.PhysicalWaters.Waterbodies");
+		layerWmsWater.setTransparent(true);
+		layerWmsWater.setFormat("image/png");
+		groupAreas.addComponent(layerWmsWater);
+
+		LTileLayerWms layerWmsStreets = new LTileLayerWms("Streets");
+		layerWmsStreets.setUrl("http://www.01.ign.es/wms-inspire/ign-base");
+		layerWmsStreets
+				.setLayers("Autopista,Autopista_Autovia,VialUrbano,CarreteraAutonomica,"
+						+ "CarreteraConvencional,CarreteraNacional");
+		layerWmsStreets.setTransparent(true);
+		layerWmsStreets.setFormat("image/png");
+		layerWmsStreets.setActive(false);
+
+		leafletMap.addComponent(groupAreas);
+		leafletMap.addComponent(layerWmsStreets);
+
+		leafletMap.setBaseLayers(baseLayerOsm, baseLayerIgn);
+
+		return leafletMap;
+	}
+}


### PR DESCRIPTION
... layer opacity
- Add L.TileLayer.WMS options to BaseLayer so that WMS layers can
  be used as base layers.
- Implement L.TileLayer and L.TileLayer.WMS as components so that
  they can be added to map, layer groups, etc. and not only as
  base layer.
- Add layer opacity option.
- Add "active" option (default true) to AbstractLeafletComponentState
  as a means to create layers without adding them to the map (e.g.
  add them to the layers control only, thus initially being hidden
  with the user being able to activate them on-demand). Correct
  solution would be to re-think the layers control in v-leaflet so
  it wraps all the addOverlay, add... functionality.
- Add 'LayersTest' page with examples for all then changes.
