### PR TITLE
Add remaining path options

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/AbstractLeafletVector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/AbstractLeafletVector.java
@@ -1,9 +1,51 @@
 package org.vaadin.addon.leaflet;
 
+import org.vaadin.addon.leaflet.client.vaadin.AbstractLeafletVectorState;
+
 public abstract class AbstractLeafletVector extends AbstractLeafletLayer {
+
+    @Override
+    protected AbstractLeafletVectorState getState() {
+        return (AbstractLeafletVectorState) super.getState();
+    }
 
     public void setColor(String color) {
         getState().color = color;
     }
 
+    public void setStroke(Boolean stroke) {
+        getState().stroke = stroke;
+    }
+
+    public void setFill(Boolean fill) {
+        getState().fill = fill;
+    }
+
+    public void setFillColor(String fillColor) {
+        getState().fillColor = fillColor;
+    }
+
+    public void setWeight(Integer weight) {
+        getState().weight = weight;
+    }
+
+    public void setOpacity(Double opacity) {
+        getState().opacity = opacity;
+    }
+
+    public void setDashArray(String dashArray) {
+        getState().dashArray = dashArray;
+    }
+
+    public void setLineCap(String lineCap) {
+        getState().lineCap = lineCap;
+    }
+
+    public void setLineJoin(String lineJoin) {
+        getState().lineJoin = lineJoin;
+    }
+
+    public void setClickable(Boolean clickable) {
+        getState().clickable = clickable;
+    }
 }

--- a/src/main/java/org/vaadin/addon/leaflet/LPolyline.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LPolyline.java
@@ -14,14 +14,6 @@ public class LPolyline extends AbstractLeafletVector {
         getState().points = points;
     }
 
-    public void setFill(boolean fill) {
-        getState().fill = fill;
-    }
-
-    public void setFillColor(String fillColor) {
-        getState().fillColor = fillColor;
-    }
-
     public void setPoints(Point[] array) {
         getState().points = array;
     }

--- a/src/main/java/org/vaadin/addon/leaflet/client/vaadin/AbstractLeafletVectorConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/vaadin/AbstractLeafletVectorConnector.java
@@ -1,0 +1,53 @@
+package org.vaadin.addon.leaflet.client.vaadin;
+
+
+import org.peimari.gleaflet.client.PathOptions;
+
+public abstract class AbstractLeafletVectorConnector<T extends AbstractLeafletVectorState, O extends PathOptions>
+        extends AbstractLeafletLayerConnector<O> {
+
+	@Override
+	protected O createOptions() {
+ 		O o = (O) O.create();
+		AbstractLeafletVectorState s = getState();
+		if (s.stroke != null) {
+			o.setStroke(s.stroke);
+		}
+		if (s.fill != null) {
+			o.setFill(s.fill);
+		}
+		if (s.fillColor != null) {
+			o.setFillColor(s.fillColor);
+		}
+		if (s.weight != null) {
+			o.setWeight(s.weight);
+		}
+		if (s.opacity != null) {
+			o.setOpacity(s.opacity);
+		}
+		if (s.dashArray != null) {
+			o.setDashArray(s.dashArray);
+		}
+		if (s.lineCap != null) {
+			o.setLineCap(s.lineCap);
+		}
+		if (s.lineJoin != null) {
+			o.setLineJoin(s.lineJoin);
+		}
+		if (s.clickable != null) {
+			o.setClickable(s.clickable);
+		}
+		if (s.pointerEvents != null) {
+			o.setPointerEvents(s.pointerEvents);
+		}
+		if (s.className != null) {
+			o.setClassName(s.className);
+		}
+		return o;
+	}
+
+	@Override
+	public AbstractLeafletVectorState getState() {
+		return (AbstractLeafletVectorState) super.getState();
+	}
+}

--- a/src/main/java/org/vaadin/addon/leaflet/client/vaadin/AbstractLeafletVectorState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/vaadin/AbstractLeafletVectorState.java
@@ -1,0 +1,27 @@
+package org.vaadin.addon.leaflet.client.vaadin;
+
+
+public class AbstractLeafletVectorState extends AbstractLeafletComponentState {
+
+    public Boolean stroke;
+
+    public Boolean fill;
+
+    public String fillColor;
+
+    public Integer weight;
+
+    public Double opacity;
+
+    public String dashArray;
+
+    public String lineCap;
+
+    public String lineJoin;
+
+    public Boolean clickable;
+
+    public String pointerEvents;
+
+    public String className;
+}

--- a/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletCircleState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletCircleState.java
@@ -1,7 +1,10 @@
 package org.vaadin.addon.leaflet.client.vaadin;
 
+import org.vaadin.addon.leaflet.shared.Point;
 
-public class LeafletCircleState extends LeafletMarkerState {
+
+public class LeafletCircleState extends AbstractLeafletVectorState {
 
 	public double radius;
+	public Point point;
 }

--- a/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletPolylineConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletPolylineConnector.java
@@ -14,7 +14,7 @@ import com.vaadin.shared.ui.Connect;
 
 @Connect(org.vaadin.addon.leaflet.LPolyline.class)
 public class LeafletPolylineConnector extends
-		AbstractLeafletLayerConnector<PolylineOptions> {
+		AbstractLeafletVectorConnector<LeafletPolylineState, PolylineOptions> {
 
 	private Polyline marker;
 
@@ -25,7 +25,7 @@ public class LeafletPolylineConnector extends
 
 	@Override
 	protected PolylineOptions createOptions() {
-		PolylineOptions o = PolylineOptions.create();
+		PolylineOptions o = super.createOptions();
 		LeafletPolylineState s = getState();
 		if (s.color != null) {
 			o.setColor(s.color);
@@ -60,7 +60,7 @@ public class LeafletPolylineConnector extends
 						.getLatLng().getLongitude()));
 			}
 		});
-		
+
 		addToParent(marker);
 	}
 

--- a/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletPolylineState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/vaadin/LeafletPolylineState.java
@@ -2,10 +2,7 @@ package org.vaadin.addon.leaflet.client.vaadin;
 
 import org.vaadin.addon.leaflet.shared.Point;
 
-public class LeafletPolylineState extends AbstractLeafletComponentState {
+public class LeafletPolylineState extends AbstractLeafletVectorState {
 
 	public Point[] points;
-	public Boolean fill;
-	public String fillColor;
-
 }

--- a/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/BasicTest.java
+++ b/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/BasicTest.java
@@ -77,6 +77,10 @@ public class BasicTest extends AbstractTest {
 		leafletPolyline.setColor("#FF00FF");
 		leafletPolyline.setFill(true);
 		leafletPolyline.setFillColor("#00FF00");
+		leafletPolyline.setClickable(false);
+		leafletPolyline.setWeight(8);
+		leafletPolyline.setOpacity(0.5);
+		leafletPolyline.setDashArray("15, 10, 5, 10, 15");
 		leafletPolyline.addClickListener(listener);
 		leafletMap.addComponent(leafletPolyline);
 


### PR DESCRIPTION
- Extract path options into base class `AbstractLeafletVectorState` with appropriate setters in `AbstractLeafletVectorConnector` so they can be re-used in other path-type objetcs (e.g. circle, circle marker, etc.).
- Add missing path options.
