### PR TITLE
Added EPSG support to editing fields - plus minor typo fixed

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/util/AbstractJTSField.java
+++ b/src/main/java/org/vaadin/addon/leaflet/util/AbstractJTSField.java
@@ -4,6 +4,7 @@ import org.vaadin.addon.leaflet.LMap;
 import org.vaadin.addon.leaflet.LTileLayer;
 
 import com.vaadin.client.ui.Field;
+import com.vaadin.data.Property;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CustomField;
 import com.vividsolutions.jts.geom.Geometry;
@@ -56,6 +57,16 @@ public abstract class AbstractJTSField<T extends Geometry> extends
 	protected LMap map = new LMap();
 
 	private Configurator configurator;
+	
+	private int srid = 4326;
+	
+	/**
+	 * Set the EPSG Spatial Reference Identifier (SRID)
+	 * which defaults to 4326.
+	 */
+	public void setSrid(int srid) {
+        this.srid = srid;
+    }
 
 	public AbstractJTSField() {
 		super();
@@ -93,11 +104,19 @@ public abstract class AbstractJTSField<T extends Geometry> extends
 		if (newValue == null) {
 			prepareDrawing();
 		} else {
-			prapareEditing();
+			prepareEditing();
 		}
 	}
-
-	protected abstract void prapareEditing();
+	
+	@Override
+	public void setValue(T value) {
+	    if (value != null) {
+	        value.setSRID(srid);
+	    }
+	    super.setValue(value);
+	}
+	
+	protected abstract void prepareEditing();
 
 	protected abstract void prepareDrawing();
 

--- a/src/main/java/org/vaadin/addon/leaflet/util/JTSUtil.java
+++ b/src/main/java/org/vaadin/addon/leaflet/util/JTSUtil.java
@@ -151,7 +151,7 @@ public class JTSUtil {
 	 * @param polygon
 	 * @return
 	 */
-	private static LPolygon toPolygon(Polygon polygon) {
+	public static LPolygon toPolygon(Polygon polygon) {
 		Coordinate[] coords = polygon.getBoundary().getCoordinates();
 		Point[] points = toPointArray(coords);
 
@@ -206,6 +206,11 @@ public class JTSUtil {
 	public static LinearRing toLinearRing(LPolygon polygon) {
 		Point[] points = polygon.getPoints();
 		return toLinearRing(points);
+	}
+
+	public static Polygon toPolygon(LPolygon polygon) {
+		Point[] points = polygon.getPoints();
+		return new Polygon(toLinearRing(points), null, new GeometryFactory());
 	}
 
 	private static LinearRing toLinearRing(Point[] points) {

--- a/src/main/java/org/vaadin/addon/leaflet/util/LineStringField.java
+++ b/src/main/java/org/vaadin/addon/leaflet/util/LineStringField.java
@@ -29,7 +29,7 @@ public class LineStringField extends AbstractJTSField<LineString> {
 		return LineString.class;
 	}
 
-	protected void prapareEditing() {
+	protected void prepareEditing() {
 		if(lPolyline == null ) {
 			lPolyline = new LPolyline();
 			map.addLayer(lPolyline);

--- a/src/main/java/org/vaadin/addon/leaflet/util/LinearRingField.java
+++ b/src/main/java/org/vaadin/addon/leaflet/util/LinearRingField.java
@@ -29,7 +29,7 @@ public class LinearRingField extends AbstractJTSField<LinearRing> {
 		return LinearRing.class;
 	}
 
-	protected void prapareEditing() {
+	protected void prepareEditing() {
 		if (lPolygon == null) {
 			lPolygon = new LPolygon();
 			map.addLayer(lPolygon);

--- a/src/main/java/org/vaadin/addon/leaflet/util/PointField.java
+++ b/src/main/java/org/vaadin/addon/leaflet/util/PointField.java
@@ -27,7 +27,7 @@ public class PointField extends AbstractJTSField<Point> {
 		return Point.class;
 	}
 
-	protected void prapareEditing() {
+	protected void prepareEditing() {
 		if (marker == null) {
 			marker = new LMarker(JTSUtil.toLeafletPoint(getInternalValue()));
 			marker.addDragEndListener(new DragEndListener() {

--- a/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/EditingTest.java
+++ b/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/EditingTest.java
@@ -14,12 +14,16 @@ import org.vaadin.addon.leaflet.draw.LDraw.FeatureModifiedEvent;
 import org.vaadin.addon.leaflet.draw.LDraw.FeatureModifiedListener;
 import org.vaadin.addon.leaflet.draw.LEditing;
 import org.vaadin.addon.leaflet.shared.Point;
+import org.vaadin.addon.leaflet.util.AbstractJTSField;
+import org.vaadin.addon.leaflet.util.JTSUtil;
+import org.vaadin.addon.leaflet.util.LinearRingField;
 
 import com.vaadin.ui.Button;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Button.ClickListener;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Notification;
+import com.vividsolutions.jts.geom.LinearRing;
 
 public class EditingTest extends AbstractTest implements
 		FeatureModifiedListener {
@@ -85,6 +89,18 @@ public class EditingTest extends AbstractTest implements
 				content.addComponent(button);
 			}
 		}
+		
+		AbstractJTSField<LinearRing> c = new LinearRingField("Linear ring");
+		LPolygon polygon = new LPolygon(new Point(0, 0), new Point(30, 30),
+				new Point(30, 0));
+		LinearRing ring = JTSUtil.toLinearRing(polygon);
+		c.setValue(ring);
+		c.setHeight("200px");
+		c.setWidth("200px");
+
+        content.addComponent(c);
+		
+		
 
 		content.addComponent(new Button("Stop editing",
 				new Button.ClickListener() {


### PR DESCRIPTION
I had found that the SRID information was being lost when converting from JTS -> leaflet and back.  Making sure the SRID is set in the geometry each time the field value is set fixes this. This however requires prior knowledge of the SRID when creating new features, therefore a default SRID  (4326) has been set, which can be changed with a setter.
