### PR TITLE
Unwanted layers control

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/LMap.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LMap.java
@@ -32,6 +32,8 @@ public class LMap extends AbstractComponentContainer {
 
 	private List<Component> components = new ArrayList<Component>();
 
+	private boolean useDefaultLayersControl = true;
+	
 	public LMap() {
 		setSizeFull();
 		registerRpc(new LeafletMapServerRpc() {
@@ -50,6 +52,11 @@ public class LMap extends AbstractComponentContainer {
 
 	}
 
+	public LMap(boolean useDefaultLayersControl) {
+		this();
+		this.useDefaultLayersControl = useDefaultLayersControl;
+	}
+	
 	@Override
 	public void beforeClientResponse(boolean initial) {
 		rendered = true;
@@ -94,6 +101,9 @@ public class LMap extends AbstractComponentContainer {
 	}
 
 	public LLayers getLayersControl() {
+		if (!useDefaultLayersControl) {
+			return null;
+		}
 		for (Extension e : getExtensions()) {
 			if (e instanceof LLayers) {
 				return (LLayers) e;
@@ -287,4 +297,7 @@ public class LMap extends AbstractComponentContainer {
 		}
 	}
 
+	public void setUseDefaultLayersControl(boolean useDefault) {
+		this.useDefaultLayersControl = useDefault;
+	}
 }


### PR DESCRIPTION
LMap.addLayers allows layers to be added to a map without having a Layers Control created and displayed.

However, removing a layer by calling LMap.removeComponent causes a Layers Control to be created and displayed on the map.

This update allows the caller to control whether the default Layers Control should be created or not by checking a flag in the getLayersControl method.  The flag defaults to true so as not to impact existing code.  It can be set via a new constructor or a setter.
