### PR TITLE
Unwanted layers control

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/LMap.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LMap.java
@@ -32,8 +32,6 @@ public class LMap extends AbstractComponentContainer {
 
 	private List<Component> components = new ArrayList<Component>();
 
-	private boolean useDefaultLayersControl = true;
-	
 	public LMap() {
 		setSizeFull();
 		registerRpc(new LeafletMapServerRpc() {
@@ -52,11 +50,6 @@ public class LMap extends AbstractComponentContainer {
 
 	}
 
-	public LMap(boolean useDefaultLayersControl) {
-		this();
-		this.useDefaultLayersControl = useDefaultLayersControl;
-	}
-	
 	@Override
 	public void beforeClientResponse(boolean initial) {
 		rendered = true;
@@ -101,9 +94,6 @@ public class LMap extends AbstractComponentContainer {
 	}
 
 	public LLayers getLayersControl() {
-		if (!useDefaultLayersControl) {
-			return null;
-		}
 		for (Extension e : getExtensions()) {
 			if (e instanceof LLayers) {
 				return (LLayers) e;
@@ -134,6 +124,10 @@ public class LMap extends AbstractComponentContainer {
 		addComponent(layer);
 	}
 
+	public void removeLayer(LeafletLayer layer) {
+		removeComponent(layer);
+	}
+	
 	@Override
 	public void addComponent(Component c) {
 		if (!(c instanceof LeafletLayer)) {
@@ -149,10 +143,12 @@ public class LMap extends AbstractComponentContainer {
 	public void removeComponent(Component c) {
 		super.removeComponent(c);
 		components.remove(c);
-		LLayers layersControl = getLayersControl();
-		if (layersControl != null) {
-			layersControl.removeLayer((LeafletLayer) c);
-		}
+		if (hasControl(LLayers.class)) {
+			LLayers layersControl = getLayersControl();
+			if (layersControl != null) {
+				layersControl.removeLayer((LeafletLayer) c);
+			}
+		}	
 		markAsDirty(); // ?? is this really needed
 	}
 
@@ -161,6 +157,15 @@ public class LMap extends AbstractComponentContainer {
 		return components.size();
 	}
 
+	public boolean hasControl(Class<? extends AbstractControl> leafletControl) {
+		for (Extension e : getExtensions()) {
+			if (leafletControl.isInstance(e)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
 	public boolean hasComponent(Component component) {
 		return components.contains(component);
 	}
@@ -296,8 +301,5 @@ public class LMap extends AbstractComponentContainer {
 			zoomToExtent(geometry);
 		}
 	}
-
-	public void setUseDefaultLayersControl(boolean useDefault) {
-		this.useDefaultLayersControl = useDefault;
-	}
 }
+

--- a/src/main/java/org/vaadin/addon/leaflet/control/LLayers.java
+++ b/src/main/java/org/vaadin/addon/leaflet/control/LLayers.java
@@ -6,7 +6,7 @@ import org.vaadin.addon.leaflet.shared.LayerControlInfo;
 
 import com.vaadin.server.AbstractExtension;
 
-public class LLayers extends AbstractExtension {
+public class LLayers extends AbstractControl {
 
 	public void addOverlay(LeafletLayer overlay, String name) {
 		LayerControlInfo info = new LayerControlInfo();

--- a/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/HasControlTest.java
+++ b/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/HasControlTest.java
@@ -1,0 +1,242 @@
+package org.vaadin.addon.leaflet.demoandtestapp;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.vaadin.addon.leaflet.LMap;
+import org.vaadin.addon.leaflet.LTileLayer;
+import org.vaadin.addon.leaflet.control.LAttribution;
+import org.vaadin.addon.leaflet.control.LLayers;
+import org.vaadin.addon.leaflet.control.LScale;
+import org.vaadin.addon.leaflet.control.LZoom;
+import org.vaadin.addon.leaflet.demoandtestapp.util.AbstractTest;
+
+import com.vaadin.data.Property.ValueChangeEvent;
+import com.vaadin.data.Property.ValueChangeListener;
+import com.vaadin.shared.ui.label.ContentMode;
+import com.vaadin.ui.CheckBox;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.Notification;
+import com.vaadin.ui.Notification.Type;
+import com.vaadin.ui.OptionGroup;
+import com.vaadin.ui.Panel;
+import com.vaadin.ui.VerticalLayout;
+
+public class HasControlTest extends AbstractTest {
+
+	String attrUSGS = "Tiles courtesy of U.S. Geological Survey";
+
+	private LMap map;
+	private LTileLayer currentBaseMap;
+	
+	private List<LayerWrapper> baseLayers;
+	private List<LayerWrapper> overLays;
+	
+	private int overlayZindex = 100;
+	@Override
+	public String getDescription() {
+		return "Add/remove layers without LLayers (tests hasControl method)";
+	}
+
+	@Override
+	public Component getTestComponent() {
+		
+		map = new LMap();
+		map.setCenter(40, -105.2);
+		map.setZoomLevel(11);
+		map.addControl(new LScale());
+		
+		return map;
+	}
+
+	
+	@Override
+	protected void setup() {
+		super.setup();
+		
+		Label l = new Label("This test adds and removes overlay layers using addLayers and removeLayers.<br/> " +
+				"A Leaflet Layers Control should never appear.", 
+				ContentMode.HTML);
+		l.setWidth("500px");
+		
+		HorizontalLayout hl = new HorizontalLayout();
+		CheckBox useLLayers = new CheckBox("Use LLayers control", false);
+		useLLayers.addValueChangeListener(new ValueChangeListener() {
+			
+			@Override
+			public void valueChange(ValueChangeEvent event) {
+				CheckBox cb = (CheckBox) event.getProperty();
+				boolean checked = cb.getValue();
+				if (checked) {
+					LLayers lc = new LLayers();
+					map.addControl(lc);
+					for (LayerWrapper lw : baseLayers) {
+						lc.addBaseLayer(lw.getLayer(), lw.getDescription());
+					}
+					for (LayerWrapper lw : overLays) {
+						lc.addOverlay(lw.getLayer(), lw.getDescription());
+					}
+				} else {
+					map.removeControl(map.getLayersControl());
+				}
+			}
+		});
+		hl.addComponents(l,setupBaseMaps(), setupOverlays(), useLLayers);
+		
+		content.addComponentAsFirst(hl);
+	}
+
+	private Component setupOverlays() {
+		// These are actually basemaps, but we'll dial down the opacity to use as overlays.
+		LayerWrapper shl = createOverlay(
+				"http://basemap.nationalmap.gov/ArcGIS/rest/services/USGSShadedReliefOnly/MapServer/tile/{z}/{y}/{x}",
+				"USGS Shaded Relief "
+		);
+		
+		LayerWrapper cl = createOverlay(
+				"http://basemap.nationalmap.gov/ArcGIS/rest/services/TNM_Contours/MapServer/tile/{z}/{y}/{x}",
+				"USGS Contours"
+		);
+		
+		overLays = Arrays.asList(shl, cl);
+		
+		CheckBox sh = createOverLayCheckBox(shl);
+		CheckBox c = createOverLayCheckBox(cl);
+		
+		VerticalLayout vl = new VerticalLayout();
+		vl.addComponents(sh, c);
+		vl.setSizeUndefined();
+	
+		Panel p = new Panel();
+		p.setCaption("Overlay maps");
+		p.setContent(vl);
+		p.setSizeUndefined();
+		
+		map.addLayer(shl.getLayer());
+		map.addLayer(cl.getLayer());
+		//map.addOverlay(shl.getLayer(), shl.getDescription());
+		//map.addOverlay(cl.getLayer(), cl.getDescription());
+		return p;
+	}
+
+	private CheckBox createOverLayCheckBox(LayerWrapper lw) {
+		CheckBox c = new CheckBox(lw.getDescription(), false);
+		c.setImmediate(true);
+		c.setData(lw);
+		c.addValueChangeListener(ovListener);
+		
+		return c;
+	}
+	
+	private ValueChangeListener ovListener = new ValueChangeListener() {
+		
+		@Override
+		public void valueChange(ValueChangeEvent event) {
+			String hasControls = "has LLayers? " + map.hasControl(LLayers.class) +
+					"\nhas Scale? " + map.hasControl(LScale.class);
+			Notification.show(hasControls);
+			CheckBox cb = (CheckBox) event.getProperty();
+			boolean checked = cb.getValue();
+			LayerWrapper lw = (LayerWrapper) cb.getData();
+			if (checked) {
+				lw.getLayer().setActive(true);
+				map.addLayer(lw.getLayer());
+				
+			} else {
+				lw.getLayer().setActive(false);
+				map.removeLayer(lw.getLayer());
+			}
+			//lw.getLayer().setActive(checked);
+			trayNotify("Layer " + cb.getCaption() + " should now be " + (checked ? "" : "not") + " visible");
+		}
+	};
+	
+	private LayerWrapper createOverlay(String url, String desc) {
+		Double opacity = 0.6;
+		
+		LTileLayer l = new LTileLayer();
+		l.setUrl(url);
+		l.setAttributionString(attrUSGS);
+		l.setOpacity(opacity);
+		l.setActive(false);
+		l.setZindex(overlayZindex++);
+		return new LayerWrapper(desc, l);
+	}
+	
+	private Component setupBaseMaps() {
+		
+		baseLayers = getBaseLayers();
+		currentBaseMap = baseLayers.get(0).getLayer();
+
+		OptionGroup base = new OptionGroup("Base maps", baseLayers);
+		base.setValue(baseLayers.get(0));
+		base.setImmediate(true);
+		
+		
+		base.addValueChangeListener(new ValueChangeListener() {
+			
+			@Override
+			public void valueChange(ValueChangeEvent event) {
+				currentBaseMap.setActive(false);
+				LayerWrapper lw = (LayerWrapper) event.getProperty().getValue();
+				lw.getLayer().setActive(true);
+				currentBaseMap = lw.getLayer();
+				trayNotify("Switched base map to " + lw.getDescription());
+			}
+		});
+		
+		for (LayerWrapper lw : baseLayers) {
+			//map.addBaseLayer(lw.getLayer(), lw.getDescription());
+			map.addLayer(lw.getLayer());
+		}
+		
+		return base;
+	}
+	
+	private List<LayerWrapper> getBaseLayers() {
+		
+		LTileLayer aer = new LTileLayer();
+		aer.setUrl("http://basemap.nationalmap.gov/ArcGIS/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}");
+		aer.setAttributionString(attrUSGS);
+		aer.setActive(false);
+		
+		LTileLayer tf = new LTileLayer();
+		tf.setUrl("http://{s}.tile.thunderforest.com/transport/{z}/{x}/{y}.png");
+		tf.setAttributionString("Tiles Courtesy of <a href=\"http://www.thunderforest.com/\" target=\"_blank\">Thunderforest</a>" + 
+								"&nbspand OpenStreetMap contributors");
+		tf.setSubDomains(new String[]{"a", "b", "c"});
+		tf.setActive(true);
+		
+		return Arrays.asList(new LayerWrapper("ThunderForest Transport ", tf), new LayerWrapper("USGS Aerial", aer));
+	}
+	
+	private void trayNotify(String msg) {
+		Notification.show(msg, Type.TRAY_NOTIFICATION);
+	}
+	private static class LayerWrapper {
+		private String description;
+		private LTileLayer layer;
+		
+		LayerWrapper(String description, LTileLayer layer) {
+			super();
+			this.description = description;
+			this.layer = layer;
+		}
+		
+		String getDescription() {
+			return description;
+		}
+		
+		LTileLayer getLayer() {
+			return layer;
+		}
+
+		@Override
+		public String toString() {
+			return getDescription();
+		}
+	}
+}


### PR DESCRIPTION
LMap.addLayers allows layers to be added to a map without having a Layers Control created and displayed.

However, removing a layer by calling LMap.removeComponent causes a LayersControl to be created and displayed on the map.

This update allows the caller to explicitly control whether the default Layers Control should be created or not by checking a flag in the getLayersControl method.
