### PR TITLE
Revert "changed rectangles client side implementation...

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/LRectangle.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LRectangle.java
@@ -1,12 +1,17 @@
 package org.vaadin.addon.leaflet;
 
-import org.vaadin.addon.leaflet.shared.Bounds;
+import com.vividsolutions.jts.geom.Geometry;
 import org.vaadin.addon.leaflet.shared.Point;
+
+import org.vaadin.addon.leaflet.client.LeafletRectangleState;
+import org.vaadin.addon.leaflet.shared.Bounds;
 import org.vaadin.addon.leaflet.util.JTSUtil;
 
-import com.vividsolutions.jts.geom.Geometry;
-
 public class LRectangle extends LPolygon {
+
+    public LRectangle(Point sw, Point ne) {
+        this(new Bounds(sw, ne));
+    }
 
     public LRectangle(Bounds b) {
         super();
@@ -14,6 +19,7 @@ public class LRectangle extends LPolygon {
     }
 
     public void setBounds(Bounds bounds) {
+        getState().bounds = bounds;
         setPoints(
                 new Point(bounds.getSouthWestLat(), bounds.getSouthWestLon()),
                 new Point(bounds.getNorthEastLat(), bounds.getSouthWestLon()),
@@ -22,9 +28,14 @@ public class LRectangle extends LPolygon {
     }
 
     public Bounds getBounds() {
-    	return new Bounds(getPoints());
+        return getState().bounds;
     }
     
+    @Override
+    protected LeafletRectangleState getState() {
+        return (LeafletRectangleState) super.getState();
+    }
+
     @Override
     public Geometry getGeometry() {
         return JTSUtil.toLinearRing(this);

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletRectangleConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletRectangleConnector.java
@@ -1,11 +1,63 @@
 package org.vaadin.addon.leaflet.client;
 
-import com.vaadin.shared.ui.Connect;
+import org.peimari.gleaflet.client.ClickListener;
+import org.peimari.gleaflet.client.ILayer;
+import org.peimari.gleaflet.client.LatLng;
+import org.peimari.gleaflet.client.MouseEvent;
+import org.peimari.gleaflet.client.PolylineOptions;
+import org.vaadin.addon.leaflet.shared.Point;
 
-/**
- * Special connector for Rectangle only needed for drawing.
- *
- */
+import com.vaadin.shared.ui.Connect;
+import org.peimari.gleaflet.client.LatLngBounds;
+import org.peimari.gleaflet.client.MouseOutListener;
+import org.peimari.gleaflet.client.MouseOverListener;
+import org.peimari.gleaflet.client.Rectangle;
+import org.vaadin.addon.leaflet.shared.Bounds;
+import org.vaadin.addon.leaflet.shared.EventId;
+
 @Connect(org.vaadin.addon.leaflet.LRectangle.class)
 public class LeafletRectangleConnector extends LeafletPolygonConnector {
+
+    private Rectangle marker;
+
+    @Override
+    public LeafletRectangleState getState() {
+        return (LeafletRectangleState) super.getState();
+    }
+
+    @Override
+    protected void update() {
+        if (marker != null) {
+            removeLayerFromParent();
+            marker.removeClickListener();
+        }
+        if (getState().bounds == null) {
+            return;
+        }
+
+        LatLngBounds bounds = getLatLngBounds();
+        PolylineOptions options = createOptions();
+        marker = Rectangle.create(bounds, options);
+        addToParent(marker);
+
+        marker.addClickListener(new ClickListener() {
+			@Override
+			public void onClick(MouseEvent event) {
+              rpc.onClick(new Point(event.getLatLng().getLatitude(), event
+              .getLatLng().getLongitude()));
+			}
+		});
+    }
+    
+    @Override
+    public ILayer getLayer() {
+    	return marker;
+    }
+    protected LatLngBounds getLatLngBounds() {
+        Bounds b = getState().bounds;
+        LatLngBounds latlngs = LatLngBounds.create(
+                LatLng.create(b.getSouthWestLat(), b.getSouthWestLon()),
+                LatLng.create(b.getNorthEastLat(), b.getNorthEastLon()));
+        return latlngs;
+    }
 }

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletRectangleState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletRectangleState.java
@@ -1,0 +1,8 @@
+package org.vaadin.addon.leaflet.client;
+
+import org.vaadin.addon.leaflet.shared.Bounds;
+
+public class LeafletRectangleState extends LeafletPolylineState {
+
+	public Bounds bounds;
+}

--- a/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/RectangleTest.java
+++ b/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/RectangleTest.java
@@ -7,8 +7,12 @@ import org.vaadin.addon.leaflet.demoandtestapp.util.AbstractTest;
 import org.vaadin.addon.leaflet.shared.Point;
 
 import com.vaadin.ui.Component;
+import com.vaadin.ui.Notification;
+import java.util.Arrays;
+import org.vaadin.addon.leaflet.LFeatureGroup;
 import org.vaadin.addon.leaflet.LRectangle;
-import org.vaadin.addon.leaflet.shared.Bounds;
+import org.vaadin.addon.leaflet.LeafletLayer;
+import org.vaadin.addon.leaflet.draw.LDraw;
 
 public class RectangleTest extends AbstractTest {
 
@@ -16,18 +20,64 @@ public class RectangleTest extends AbstractTest {
     public String getDescription() {
         return "Test for Rectangle.";
     }
+    protected LDraw draw;
+
+    public void enableDrawing() {
+        if (null == draw) {
+            draw = new LDraw();
+            draw.setEditableFeatureGroup(featureGroup);
+
+            leafletMap.addControl(draw);
+            draw.addFeatureDrawnListener(new LDraw.FeatureDrawnListener() {
+                @Override
+                public void featureDrawn(LDraw.FeatureDrawnEvent event) {
+                    LeafletLayer feature = event.getDrawnFeature();
+                    featureGroup.addComponent(feature);
+                    Notification.show("Drawn " + feature.getClass().getSimpleName());
+                }
+            });
+
+            draw.addFeatureModifiedListener(new LDraw.FeatureModifiedListener() {
+                @Override
+                public void featureModified(LDraw.FeatureModifiedEvent event) {
+                    LeafletLayer feature = event.getModifiedFeature();
+                    Notification.show("Modified " + feature.getClass().getSimpleName());
+                    if (feature instanceof LPolyline) {
+                        LPolyline pl = (LPolyline) feature;
+                        Point[] points = pl.getPoints();
+                        System.out.println(Arrays.toString(points));
+                    }
+                }
+            });
+
+            draw.addFeatureDeletedListener(new LDraw.FeatureDeletedListener() {
+                @Override
+                public void featureDeleted(LDraw.FeatureDeletedEvent event) {
+                    LeafletLayer feature = event.getDeletedFeature();
+                    featureGroup.removeComponent(feature);
+                    Notification.show("Deleted " + feature.getClass().getSimpleName());
+                }
+            });
+        }
+    }
+
+    private LMap leafletMap;
+    private LFeatureGroup featureGroup;
 
     @Override
     public Component getTestComponent() {
-        LMap leafletMap = new LMap();
-
+        leafletMap = new LMap();
         LOpenStreetMapLayer layer = new LOpenStreetMapLayer();
         leafletMap.addBaseLayer(layer, "OSM");
         leafletMap.setCenter(0, 0);
         leafletMap.setZoomLevel(0);
 
-        LPolyline rectangle = new LRectangle(new Bounds(new Point(0, 360),new Point(60, 280)));
-        leafletMap.addComponent(rectangle);
+        LRectangle rectangle = new LRectangle(new Point(0, 360), new Point(60, 280));
+        featureGroup = new LFeatureGroup();
+        featureGroup.addComponent(rectangle);
+        leafletMap.addComponent(featureGroup);
+
+        enableDrawing();
         return leafletMap;
     }
 


### PR DESCRIPTION
...to be only a "marker" for draw stuff" and extended RectangleTest.

This reverts commit a7640fea97db65a4a0319cfb044c8cea471bfb6d.

This is for issue #67. Restoring the RectangleState and the full implementation of the LeafletRectangleConnector (that instantiates a Rectangle) makes the rectangle correctly editable.

I do not know if there is a better solution.

I have extended the RectangleTest to activate draw.
