### PR TITLE
Added custom options support to LTileLayer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <vaadin.version>7.2.6</vaadin.version>
-        <g-leaflet-draw.version>0.4.7-SNAPSHOT</g-leaflet-draw.version>
+        <g-leaflet-draw.version>0.4.8-SNAPSHOT</g-leaflet-draw.version>
         <geotools.version>10.2</geotools.version>
     </properties>
 

--- a/src/main/java/org/vaadin/addon/leaflet/LTileLayer.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LTileLayer.java
@@ -1,5 +1,8 @@
 package org.vaadin.addon.leaflet;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.vaadin.addon.leaflet.client.*;
 import org.vaadin.addon.leaflet.shared.EventId;
 
@@ -118,6 +121,21 @@ public class LTileLayer extends AbstractLeafletLayer {
 
         public void setNoWrap(Boolean noWrap) {
                 getState().noWrap = noWrap;
+        }
+
+        public Map<String, String> getCustomOptions() {
+            return getState().customOptions;
+        }
+    
+        public void setCustomOptions(Map<String, String> customOptions) {
+            getState().customOptions = customOptions;
+        }
+        
+        public void setCustomOption(String optionName, String optionValue) {
+            if(getState().customOptions == null) {
+                getState().customOptions = new HashMap<String, String>();
+            }
+            getState().customOptions.put(optionName, optionValue);
         }
 
 	@Override

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletTileLayerConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletTileLayerConnector.java
@@ -51,6 +51,11 @@ public class LeafletTileLayerConnector extends
                 if (s.noWrap != null) {
                     o.setNoWrap(s.noWrap);
                 }
+		if (s.customOptions != null) {
+		    for(String keyName : s.customOptions.keySet()) {
+		        o.setCustomOption(keyName, s.customOptions.get(keyName));
+		    }
+		}
 		return o;
 	}
 

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletTileLayerState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletTileLayerState.java
@@ -1,5 +1,7 @@
 package org.vaadin.addon.leaflet.client;
 
+import java.util.Map;
+
 public class LeafletTileLayerState extends AbstractLeafletComponentState {
 
 	public String url;
@@ -13,4 +15,5 @@ public class LeafletTileLayerState extends AbstractLeafletComponentState {
 	public Integer zIndex;
         public Boolean continuousWorld;
         public Boolean noWrap;
+        public Map<String,String> customOptions;
 }


### PR DESCRIPTION
Needs https://github.com/mstahv/g-leaflet/pull/18 to enable support in g-leaflet.
Allow applications to pass custom options to tiled layers.
For example, we use it to add a  timestamp to wms requests,to avoid cached tiles, when we update a layer.
