### PR TITLE
Update default constructor of class Bounds to initialize its fields

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/shared/Bounds.java
+++ b/src/main/java/org/vaadin/addon/leaflet/shared/Bounds.java
@@ -9,6 +9,10 @@ public class Bounds implements Serializable {
 	private double northEastLat;
 
 	public Bounds() {
+        	setSouthWestLat(Double.MAX_VALUE);
+        	setSouthWestLon(Double.MAX_VALUE);
+        	setNorthEastLat(Double.MIN_VALUE);
+        	setNorthEastLon(Double.MIN_VALUE);
 	}
 
 	public Bounds(String bounds) {


### PR DESCRIPTION
When calling the default constructor, the fields are not initialized at all, which results in wrong bounds in many cases where the extend method is called to modify the fields afterwards. This change fixes the wrong behavior by initializing the fields to practical default values.