### PR TITLE
Support for creating new Crs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
         <dependency>
             <groupId>org.peimari</groupId>
             <artifactId>g-leaflet</artifactId>
-            <version>0.4.11</version>
+            <version>0.4.12-SNAPSHOT</version>
             <!-- Only needed during widgetset compilation, so provided scope would 
             be great for this, but with it is left out from widgetset compilation by 
             vaadin plugin -->

--- a/src/main/java/org/vaadin/addon/leaflet/LMap.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LMap.java
@@ -377,7 +377,16 @@ public class LMap extends AbstractComponentContainer {
 		this.lCrs = lc;
 		getState().crsName = lc.getName();
 	}
-    
+
+	public void setNewCrs(String name, String projection, double a, double b, double c, double d) {
+		getState().newCrsName = name;
+		getState().newCrsProjection = projection;
+		getState().newCrsA = a;
+		getState().newCrsB = b;
+		getState().newCrsC = c;
+		getState().newCrsD = d;
+	}
+
     private BasicMap customMapOptions;
 
     public void setCustomInitOption(String key, boolean b) {

--- a/src/main/java/org/vaadin/addon/leaflet/LMap.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LMap.java
@@ -378,6 +378,15 @@ public class LMap extends AbstractComponentContainer {
 		getState().crsName = lc.getName();
 	}
 
+	/**
+	 * Adds and uses a new Crs definition and makes it immediately available for use inside a
+	 * Map. The new Crs extends Crs.Simple, uses the Projection as specified in the parameters
+	 * and an affine transform as specified by the a, b, c, d parameters). For the meaning of
+	 * the affine transform parameters, see: http://leafletjs.com/reference.html#transformation.
+	 * @param name Name for the new Crs.
+	 * @param projection Name of the projection for this new Crs. It needs to be the name of a
+	 * valid projection defined in L.Projection (LonLat, SphericalMercator, Mercator).
+	 */
 	public void setNewCrs(String name, String projection, double a, double b, double c, double d) {
 		getState().newCrsName = name;
 		getState().newCrsProjection = projection;

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletMapConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletMapConnector.java
@@ -159,7 +159,11 @@ public class LeafletMapConnector extends AbstractHasComponentsConnector
              * See if CRS set. Maintain backwards compatability so that EPSG:3857
              * used if nothing specified.
              */
-            if (getState().crsName != null) {
+            if (getState().newCrsName != null) {
+                options.setCrs(Crs.add(getState().newCrsName, getState().newCrsProjection,
+                        getState().newCrsA, getState().newCrsB,
+                        getState().newCrsC, getState().newCrsD));
+            } else if (getState().crsName != null) {
                 options.setCrs(Crs.byName(getState().crsName));
             }
 

--- a/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapState.java
@@ -42,4 +42,10 @@ public class LeafletMapState extends AbstractComponentState {
 	 * client.
 	 */
 	public String crsName;
+	public String newCrsName;
+	public String newCrsProjection;
+	public double newCrsA;
+	public double newCrsB;
+	public double newCrsC;
+	public double newCrsD;
 }


### PR DESCRIPTION
Hi. This change is for the definition of new CRS to be used in a Map.

One can use existing CRS with Crs.byName() and define and use new CRS with Crs.add().