### PR TITLE
Read only mode

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/LMap.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LMap.java
@@ -449,8 +449,16 @@ public class LMap extends AbstractComponentContainer {
     public void setReadOnly(boolean readOnly) {
     	super.setReadOnly(readOnly);
     	setDraggingEnabled(!readOnly);
+    	setTouchZoomEnabled(!readOnly);
+    	setDoubleClickZoomEnabled(!readOnly);
+    	setBoxZoomEnabled(!readOnly);
+    	setScrollWheelZoomEnabled(!readOnly);
+    	setKeyboardEnabled(!readOnly);
     }
 
+    /**
+     * @see <a href="http://leafletjs.com/reference-1.0.0.html#map-dragging">Leaflet.js doc</a>
+     */
 	public void setDraggingEnabled(boolean dragging) {
 		getState(!rendered).dragging = dragging;
 		if(rendered){
@@ -458,8 +466,101 @@ public class LMap extends AbstractComponentContainer {
 		}
 	};
 	
+	/**
+     * @see <a href="http://leafletjs.com/reference-1.0.0.html#map-dragging">Leaflet.js doc</a>
+     */
 	public boolean isDraggingEnabled() {
 		Boolean dragging = getState(false).dragging;
 		return dragging != null ? dragging : true;
+	}
+	
+	/**
+     * @see <a href="http://leafletjs.com/reference-1.0.0.html#map-touchzoom">Leaflet.js doc</a>
+     */
+	public void setTouchZoomEnabled(boolean touchZoom) {
+		getState(!rendered).touchZoom = touchZoom;
+		if(rendered){
+			getRpcProxy(LeafletMapClientRpc.class).setTouchZoom(touchZoom);
+		}
+	};
+	
+	/**
+     * @see <a href="http://leafletjs.com/reference-1.0.0.html#map-touchzoom">Leaflet.js doc</a>
+     */
+	public boolean isTouchZoomEnabled() {
+		Boolean touchZoom = getState(false).touchZoom;
+		return touchZoom != null ? touchZoom : true;
+	}
+	
+	/**
+     * @see <a href="http://leafletjs.com/reference-1.0.0.html#map-doubleclickzoom">Leaflet.js doc</a>
+     */
+	public void setDoubleClickZoomEnabled(boolean doubleClickZoom) {
+		getState(!rendered).doubleClickZoom = doubleClickZoom;
+		if(rendered){
+			getRpcProxy(LeafletMapClientRpc.class).setDoubleClickZoom(doubleClickZoom);
+		}
+	};
+	
+	/**
+     * @see <a href="http://leafletjs.com/reference-1.0.0.html#map-doubleclickzoom">Leaflet.js doc</a>
+     */
+	public boolean isDoubleZoomEnabled() {
+		Boolean doubleClickZoom = getState(false).doubleClickZoom;
+		return doubleClickZoom != null ? doubleClickZoom : true;
+	}
+	
+	/**
+     * @see <a href="http://leafletjs.com/reference-1.0.0.html#map-boxzoom">Leaflet.js doc</a>
+     */
+	public void setBoxZoomEnabled(boolean boxZoom) {
+		getState(!rendered).boxZoom = boxZoom;
+		if(rendered){
+			getRpcProxy(LeafletMapClientRpc.class).setBoxZoom(boxZoom);
+		}
+	};
+	
+	/**
+     * @see <a href="http://leafletjs.com/reference-1.0.0.html#map-boxzoom">Leaflet.js doc</a>
+     */
+	public boolean isBoxZoomEnabled() {
+		Boolean boxZoom = getState(false).boxZoom;
+		return boxZoom != null ? boxZoom : true;
+	}
+	
+	/**
+     * @see <a href="http://leafletjs.com/reference-1.0.0.html#map-scrollwheelzoom">Leaflet.js doc</a>
+     */
+	public void setScrollWheelZoomEnabled(boolean scrollWheelZoom) {
+		getState(!rendered).scrollWheelZoom = scrollWheelZoom;
+		if(rendered){
+			getRpcProxy(LeafletMapClientRpc.class).setScrollWheelZoom(scrollWheelZoom);
+		}
+	};
+	
+	/**
+     * @see <a href="http://leafletjs.com/reference-1.0.0.html#map-scrollwheelzoom">Leaflet.js doc</a>
+     */
+	public boolean isScrollWheelZoomEnabled() {
+		Boolean scrollWheelZoom = getState(false).scrollWheelZoom;
+		return scrollWheelZoom != null ? scrollWheelZoom : true;
+	}
+	
+	/**
+     * @see <a href="http://leafletjs.com/reference-1.0.0.html#map-keyboard">Leaflet.js doc</a>
+     */
+	public void setKeyboardEnabled(boolean keyboard) {
+		getState(!rendered).keyboard = keyboard;
+		if(rendered){
+			getRpcProxy(LeafletMapClientRpc.class).setKeyboard(keyboard);
+		}
+	};
+	
+	/**
+     * @see <a href="http://leafletjs.com/reference-1.0.0.html#map-keyboard">Leaflet.js doc</a>
+     */
+	public boolean isKeyboardZoomEnabled() {
+		Boolean keyboard = getState(false).keyboard;
+		return keyboard != null ? keyboard : true;
 	}
 }

--- a/src/main/java/org/vaadin/addon/leaflet/LMap.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LMap.java
@@ -444,4 +444,22 @@ public class LMap extends AbstractComponentContainer {
         customMapOptions.put(key, b);
         getState().customMapOptionsJson = customMapOptions.asJson();
     }
+    
+    @Override
+    public void setReadOnly(boolean readOnly) {
+    	super.setReadOnly(readOnly);
+    	setDraggingEnabled(!readOnly);
+    }
+
+	public void setDraggingEnabled(boolean dragging) {
+		getState(!rendered).dragging = dragging;
+		if(rendered){
+			getRpcProxy(LeafletMapClientRpc.class).setDragging(dragging);
+		}
+	};
+	
+	public boolean isDraggingEnabled() {
+		Boolean dragging = getState(false).dragging;
+		return dragging != null ? dragging : true;
+	}
 }

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletMapConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletMapConnector.java
@@ -147,6 +147,31 @@ public class LeafletMapConnector extends AbstractHasComponentsConnector
             public void setDragging(boolean dragging) {
             	map.setDragging(dragging);            	
             }
+            
+            @Override
+            public void setBoxZoom(boolean boxZoom) {
+            	map.setBoxZoom(boxZoom);
+            }
+            
+            @Override
+            public void setDoubleClickZoom(boolean doubleClickZoom) {
+            	map.setDoubleClickZoom(doubleClickZoom);
+            }
+            
+            @Override
+            public void setKeyboard(boolean keyboard) {
+            	map.setKeyboard(keyboard);
+            }
+            
+            @Override
+            public void setScrollWheelZoom(boolean scrollWheelZoom) {
+            	map.setScrollWheelZoom(scrollWheelZoom);
+            }
+            
+            @Override
+            public void setTouchZoom(boolean touchZoom) {
+            	map.setTouchZoom(touchZoom);
+            }
 
         });
 
@@ -200,7 +225,27 @@ public class LeafletMapConnector extends AbstractHasComponentsConnector
             if (getState().dragging != null) {
             	options.setDragging(getState().dragging);
             }
+            
+            if (getState().touchZoom != null) {
+            	options.setTouchZoom(getState().touchZoom);
+            }
 
+            if (getState().doubleClickZoom != null) {
+            	options.setDoubleClickZoom(getState().doubleClickZoom);
+            }
+            
+            if (getState().boxZoom != null) {
+            	options.setBoxZoom(getState().boxZoom);
+            }
+            
+            if (getState().scrollWheelZoom != null) {
+            	options.setScrollWheelZoom(getState().scrollWheelZoom);
+            }
+            
+            if (getState().keyboard != null) {
+            	options.setKeyboard(getState().keyboard);
+            }
+            
             if (getState().minZoom != null) {
                 options.setMinZoom(getState().minZoom);
             }

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletMapConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletMapConnector.java
@@ -142,6 +142,11 @@ public class LeafletMapConnector extends AbstractHasComponentsConnector
                 }
                 map.flyTo(center, zoom);
             }
+            
+            @Override
+            public void setDragging(Boolean dragging) {
+            	map.setDragging(dragging);            	
+            }
 
         });
 
@@ -192,6 +197,10 @@ public class LeafletMapConnector extends AbstractHasComponentsConnector
                 options.setAttributionControl(false);
             }
 
+            if (getState().dragging != null) {
+            	options.setDragging(getState().dragging);
+            }
+
             if (getState().minZoom != null) {
                 options.setMinZoom(getState().minZoom);
             }
@@ -219,7 +228,7 @@ public class LeafletMapConnector extends AbstractHasComponentsConnector
                         b.getSouthWestLon());
                 map.fitBounds(LatLngBounds.create(southWest, northEast));
             }
-
+            
             map.addClickListener(new ClickListener() {
                 public void onClick(MouseEvent event) {
                     if (hasEventListener("click")) {

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletMapConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletMapConnector.java
@@ -144,7 +144,7 @@ public class LeafletMapConnector extends AbstractHasComponentsConnector
             }
             
             @Override
-            public void setDragging(Boolean dragging) {
+            public void setDragging(boolean dragging) {
             	map.setDragging(dragging);            	
             }
 

--- a/src/main/java/org/vaadin/addon/leaflet/control/AbstractDefaultControl.java
+++ b/src/main/java/org/vaadin/addon/leaflet/control/AbstractDefaultControl.java
@@ -5,5 +5,9 @@ public abstract class AbstractDefaultControl extends AbstractControl {
 	public void setEnabled(boolean enabled) {
 		getState().enabled = enabled;
 	}
+	
+	public boolean isEnabled() {
+		return getState(false).enabled;
+	}
 
 }

--- a/src/main/java/org/vaadin/addon/leaflet/control/LLayers.java
+++ b/src/main/java/org/vaadin/addon/leaflet/control/LLayers.java
@@ -7,6 +7,16 @@ import org.vaadin.addon.leaflet.shared.LayerControlInfo;
 
 public class LLayers extends AbstractControl {
 
+	public LLayers() {
+		super();
+	}
+	public LLayers(LLayers lLayers) {
+		super();
+		LeafletLayersState state = getState();
+		state.collapsed = lLayers.getState().collapsed;
+		state.layerContolInfo = lLayers.getState().layerContolInfo;
+	}
+
 	public void addOverlay(LeafletLayer overlay, String name) {
 		LayerControlInfo info = new LayerControlInfo();
 		info.baseLayer = false;

--- a/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapClientRpc.java
+++ b/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapClientRpc.java
@@ -9,5 +9,5 @@ public interface LeafletMapClientRpc extends ClientRpc {
     void flyTo(Double lat, Double lon, Double zoom);
 	void zoomToExtent(Bounds bounds);
     void setMaxBounds(Bounds bounds);
-
+    void setDragging(Boolean dragging);
 }

--- a/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapClientRpc.java
+++ b/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapClientRpc.java
@@ -10,4 +10,9 @@ public interface LeafletMapClientRpc extends ClientRpc {
 	void zoomToExtent(Bounds bounds);
     void setMaxBounds(Bounds bounds);
     void setDragging(boolean dragging);
+    void setTouchZoom(boolean touchZoome);
+    void setDoubleClickZoom(boolean doubleClickZoom);
+    void setBoxZoom(boolean boxZoom);
+    void setScrollWheelZoom(boolean scrollWheelZoom);
+    void setKeyboard(boolean keyboard);
 }

--- a/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapClientRpc.java
+++ b/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapClientRpc.java
@@ -9,5 +9,5 @@ public interface LeafletMapClientRpc extends ClientRpc {
     void flyTo(Double lat, Double lon, Double zoom);
 	void zoomToExtent(Bounds bounds);
     void setMaxBounds(Bounds bounds);
-    void setDragging(Boolean dragging);
+    void setDragging(boolean dragging);
 }

--- a/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapState.java
@@ -48,4 +48,6 @@ public class LeafletMapState extends AbstractComponentState {
 	public double newCrsB;
 	public double newCrsC;
 	public double newCrsD;
+	
+	public Boolean dragging;
 }

--- a/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapState.java
@@ -50,4 +50,9 @@ public class LeafletMapState extends AbstractComponentState {
 	public double newCrsD;
 	
 	public Boolean dragging;
+	public Boolean touchZoom;
+	public Boolean doubleClickZoom;
+	public Boolean boxZoom;
+	public Boolean scrollWheelZoom;
+	public Boolean keyboard;
 }

--- a/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/ReadOnlyTest.java
+++ b/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/ReadOnlyTest.java
@@ -2,6 +2,7 @@ package org.vaadin.addon.leaflet.demoandtestapp;
 
 import org.vaadin.addon.leaflet.LMap;
 import org.vaadin.addon.leaflet.LOpenStreetMapLayer;
+import org.vaadin.addon.leaflet.control.LZoom;
 import org.vaadin.addonhelpers.AbstractTest;
 
 import com.vaadin.ui.Button;
@@ -29,8 +30,9 @@ public class ReadOnlyTest extends AbstractTest {
 		leafletMap.setZoomLevel(10);
 		LOpenStreetMapLayer layer = new LOpenStreetMapLayer();
 		leafletMap.addBaseLayer(layer, "OSM");
+		leafletMap.addControl(new LZoom());
 		leafletMap.setReadOnly(true);
-
+		
 		Button getStates = new Button("getStates", new Button.ClickListener() {
 			@Override
 			public void buttonClick(ClickEvent event) {

--- a/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/ReadOnlyTest.java
+++ b/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/ReadOnlyTest.java
@@ -4,7 +4,13 @@ import org.vaadin.addon.leaflet.LMap;
 import org.vaadin.addon.leaflet.LOpenStreetMapLayer;
 import org.vaadin.addonhelpers.AbstractTest;
 
+import com.vaadin.ui.Button;
 import com.vaadin.ui.Component;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Notification;
+import com.vaadin.ui.VerticalLayout;
+import com.vaadin.ui.Notification.Type;
+import com.vaadin.ui.Button.ClickEvent;
 
 @SuppressWarnings("serial")
 public class ReadOnlyTest extends AbstractTest {
@@ -20,10 +26,27 @@ public class ReadOnlyTest extends AbstractTest {
 	public Component getTestComponent() {
 		leafletMap = new LMap();
 		leafletMap.setCenter(60.4525, 22.301);
-		leafletMap.setZoomLevel(15);
+		leafletMap.setZoomLevel(10);
 		LOpenStreetMapLayer layer = new LOpenStreetMapLayer();
 		leafletMap.addBaseLayer(layer, "OSM");
 		leafletMap.setReadOnly(true);
-		return leafletMap;
+
+		Button getStates = new Button("getStates", new Button.ClickListener() {
+			@Override
+			public void buttonClick(ClickEvent event) {
+				StringBuilder sb = new StringBuilder("isDraggingEnabled() = ").append(leafletMap.isDraggingEnabled());
+				Notification.show("States", sb.toString(), Type.HUMANIZED_MESSAGE);
+			}
+		});
+		Button toggleReadOnly = new Button("toggle readonly", new Button.ClickListener() {
+			@Override
+			public void buttonClick(ClickEvent event) {
+				leafletMap.setReadOnly(!leafletMap.isReadOnly());
+			}
+		});
+		VerticalLayout verticalLayout = new VerticalLayout(leafletMap, new HorizontalLayout(getStates, toggleReadOnly));
+		verticalLayout.setSizeFull();
+		verticalLayout.setExpandRatio(leafletMap, 1);
+		return verticalLayout;
 	}
 }

--- a/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/ReadOnlyTest.java
+++ b/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/ReadOnlyTest.java
@@ -34,7 +34,8 @@ public class ReadOnlyTest extends AbstractTest {
 		Button getStates = new Button("getStates", new Button.ClickListener() {
 			@Override
 			public void buttonClick(ClickEvent event) {
-				StringBuilder sb = new StringBuilder("isDraggingEnabled() = ").append(leafletMap.isDraggingEnabled());
+				StringBuilder sb = new StringBuilder("\nisDraggingEnabled() = ").append(leafletMap.isDraggingEnabled())
+						.append("\nisBooxZoomEnabled() = ").append(leafletMap.isBoxZoomEnabled());
 				Notification.show("States", sb.toString(), Type.HUMANIZED_MESSAGE);
 			}
 		});

--- a/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/ReadOnlyTest.java
+++ b/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/ReadOnlyTest.java
@@ -1,0 +1,29 @@
+package org.vaadin.addon.leaflet.demoandtestapp;
+
+import org.vaadin.addon.leaflet.LMap;
+import org.vaadin.addon.leaflet.LOpenStreetMapLayer;
+import org.vaadin.addonhelpers.AbstractTest;
+
+import com.vaadin.ui.Component;
+
+@SuppressWarnings("serial")
+public class ReadOnlyTest extends AbstractTest {
+
+	@Override
+	public String getDescription() {
+		return "A visual test for the readOnly feature.";
+	}
+
+	private LMap leafletMap;
+
+	@Override
+	public Component getTestComponent() {
+		leafletMap = new LMap();
+		leafletMap.setCenter(60.4525, 22.301);
+		leafletMap.setZoomLevel(15);
+		LOpenStreetMapLayer layer = new LOpenStreetMapLayer();
+		leafletMap.addBaseLayer(layer, "OSM");
+		leafletMap.setReadOnly(true);
+		return leafletMap;
+	}
+}


### PR DESCRIPTION
Implementing read only for the LMap. In the read only mode, no modification in the map are possible (zooming and dragging) and the controls are hidden.
State before read only mode is preserved, for switching back to read write mode.