### PR TITLE
Support usage of JTSFields without bean binding

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/util/AbstractJTSField.java
+++ b/src/main/java/org/vaadin/addon/leaflet/util/AbstractJTSField.java
@@ -155,5 +155,13 @@ public abstract class AbstractJTSField<T extends Geometry> extends
 	public void setCRSTranslator(CRSTranslator crsTranslator) {
 		this.crsTranslator = crsTranslator;
 	}
+	
+	@Override
+	public void attach() {
+		super.attach();
+		if (getValue() == null) {
+			prepareDrawing();
+		}
+	}
 
 }

--- a/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/WithoutBeanBindingTest.java
+++ b/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/WithoutBeanBindingTest.java
@@ -1,0 +1,65 @@
+package org.vaadin.addon.leaflet.demoandtestapp;
+
+import org.vaadin.addon.leaflet.util.PointField;
+import org.vaadin.addonhelpers.AbstractTest;
+
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Button.ClickEvent;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.HorizontalLayout;
+import com.vaadin.ui.Notification;
+import com.vaadin.ui.VerticalLayout;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+
+public class WithoutBeanBindingTest extends AbstractTest {
+	private WKTReader wkt = new WKTReader();
+
+	@Override
+	public String getDescription() {
+		return "A simple test for JTSFields without bean binding";
+	}
+
+	@Override
+	public Component getTestComponent() {
+		final PointField pointFieldEmpty = new PointField("empty PointField");
+		pointFieldEmpty.setSizeFull();
+
+		final PointField pointFieldInitialized = new PointField("PointField with value");
+		pointFieldInitialized.setSizeFull();
+		pointFieldInitialized.setValue(getPoint());
+
+		Button getValueButton = new Button("Get values");
+		getValueButton.addClickListener(new Button.ClickListener() {
+			@Override
+			public void buttonClick(ClickEvent event) {
+				Point value1 = pointFieldEmpty.getValue();
+				Point value2 = pointFieldInitialized.getValue();
+				Notification.show(value1 + "\n" + value2);
+			}
+		});
+		HorizontalLayout fieldLayout = new HorizontalLayout(pointFieldEmpty, pointFieldInitialized);
+		fieldLayout.setSizeFull();
+		fieldLayout.setSpacing(true);
+		VerticalLayout layout = new VerticalLayout(fieldLayout, getValueButton);
+		layout.setExpandRatio(fieldLayout, 1f);
+		layout.setSizeFull();
+		layout.setSpacing(true);
+		return layout;
+	}
+
+	private Geometry readWKT(String wktString) {
+		try {
+			return wkt.read(wktString);
+		} catch (ParseException e) {
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	private Point getPoint() {
+		return (Point) readWKT("POINT (23 64)");
+	}
+}


### PR DESCRIPTION
Before these patch JTSFields did not switch to drawing mode if there was no setValue() call or setValue(null). Now there is a check in attach() to trigger drawing mode if necessary.