### PR TITLE
Added 'zIndexOffset' functionality to LMarker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,8 @@
         <dependency>
             <groupId>org.peimari</groupId>
             <artifactId>g-leaflet</artifactId>
-            <version>1.0.0-rc1</version>
+            <!--<version>1.0.0-rc1</version>-->
+            <version>1.0.0-b7-SNAPSHOT</version>
             <!-- Only needed during widgetset compilation, so provided scope would 
             be great for this, but with it is left out from widgetset compilation by 
             vaadin plugin -->

--- a/src/main/java/org/vaadin/addon/leaflet/LMarker.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LMarker.java
@@ -116,5 +116,9 @@ public class LMarker extends AbstractLeafletLayer {
 		return JTSUtil.toPoint(this);
 	}
 
+    public void setZIndexOffset(Integer zIndexOffset) {
+        getState().zIndexOffset = zIndexOffset;
+    }
+
 
 }

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletMarkerConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletMarkerConnector.java
@@ -151,6 +151,12 @@ public class LeafletMarkerConnector extends
         if (hasEventListener("dragend")) {
             options.setDraggable(true);
         }
+        
+        Integer zIndexOffset = getState().zIndexOffset;
+        if (zIndexOffset != null)
+        {
+            options.setZIndexOffset(zIndexOffset);
+        }
 
         marker = Marker.create(latlng, options);
         if (hasEventListener("dragend")) {

--- a/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMarkerState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMarkerState.java
@@ -11,5 +11,6 @@ public class LeafletMarkerState extends AbstractLeafletComponentState {
 	public String popup;
 	public PopupState popupState;
 	public Boolean draggable;
+    public Integer zIndexOffset;
 	
 }


### PR DESCRIPTION
Note: I also updated the dependency of v-leaflet to point to the SNAPSHOT version of g-leaflet that contains zIndexOffset functionality. Not sure if it was necessary to commit this change or not.