### PR TITLE
Supports the creation of CRS with plat-carré projections with defined…

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/LMap.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LMap.java
@@ -498,6 +498,31 @@ public class LMap extends AbstractComponentContainer {
         getState().newCrsD = d;
     }
 
+    /**
+     * Adds and uses a new Crs definition and makes it immediately available for
+     * use inside a Map. The new Crs extends Crs.Simple, uses a plat-carré projection with the
+     * extents given by the min_* and max_* parameters. For the meaning of the affine transform
+     * parameters, see: http://leafletjs.com/reference.html#transformation.
+     *
+     * @param name Name for the new Crs.
+     * @param a transformation parameter a
+     * @param b transformation parameter b
+     * @param c transformation parameter c
+     * @param d transformation parameter d
+     */
+    public void setCustomCrs(String name, double min_x, double min_y, double max_x, double max_y,
+            double a, double b, double c, double d) {
+        getState().newCrsName = name;
+        getState().newCrsMinX = min_x;
+        getState().newCrsMinY = min_y;
+        getState().newCrsMaxX = max_x;
+        getState().newCrsMaxY = max_y;
+        getState().newCrsA = a;
+        getState().newCrsB = b;
+        getState().newCrsC = c;
+        getState().newCrsD = d;
+    }
+
     private BasicMap customMapOptions;
 
     public void setCustomInitOption(String key, boolean b) {

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletMapConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletMapConnector.java
@@ -282,9 +282,17 @@ public class LeafletMapConnector extends AbstractHasComponentsConnector
              * used if nothing specified.
              */
             if (getState().newCrsName != null) {
+                if (getState().newCrsProjection != null) {
                 options.setCrs(Crs.add(getState().newCrsName, getState().newCrsProjection,
                         getState().newCrsA, getState().newCrsB,
                         getState().newCrsC, getState().newCrsD));
+                } else {
+                    options.setCrs(Crs.add(getState().newCrsName,
+                            getState().newCrsMinX, getState().newCrsMinY,
+                            getState().newCrsMaxX, getState().newCrsMaxY,
+                            getState().newCrsA, getState().newCrsB,
+                            getState().newCrsC, getState().newCrsD));
+                }
             } else if (getState().crsName != null) {
                 options.setCrs(Crs.byName(getState().crsName));
             }

--- a/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/shared/LeafletMapState.java
@@ -49,7 +49,11 @@ public class LeafletMapState extends AbstractComponentState {
 	public double newCrsB;
 	public double newCrsC;
 	public double newCrsD;
-	
+	public double newCrsMinX;
+	public double newCrsMinY;
+	public double newCrsMaxX;
+	public double newCrsMaxY;
+
 	public Boolean dragging;
 	public Boolean touchZoom;
 	public Boolean doubleClickZoom;


### PR DESCRIPTION
… bounds.

This change allows the creation of new CRS. As (AFAIK) Leaflet introduced the idea of bounds for projections, the previous Crs.add() method worked only for coordinates valid inside the specified projection.
I used LatLong, that is currently bound to [-180,-90]-[180,90]. That's not OK for me, beacuse I need wider bounds in my non-geographic maps.