### PR TITLE
Add support for 'nonBubblingEvents' option

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/AbstractLeafletVector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/AbstractLeafletVector.java
@@ -89,6 +89,10 @@ public abstract class AbstractLeafletVector extends AbstractLeafletLayer {
         getState().clickable = clickable;
     }
 
+    public void setNonBubblingEvents(String[] nonBubblingEvents) {
+        getState().nonBubblingEvents = nonBubblingEvents;
+    }
+
     public void setTooltip(String tooltip) {
         getState().tooltip = tooltip;
     }

--- a/src/main/java/org/vaadin/addon/leaflet/client/AbstractLeafletVectorConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/AbstractLeafletVectorConnector.java
@@ -1,5 +1,6 @@
 package org.vaadin.addon.leaflet.client;
 
+import com.google.gwt.core.client.JsArrayString;
 import org.vaadin.addon.leaflet.shared.AbstractLeafletVectorState;
 import org.vaadin.addon.leaflet.shared.LeafletMarkerClientRpc;
 import com.google.gwt.core.client.JsonUtils;
@@ -60,7 +61,15 @@ public abstract class AbstractLeafletVectorConnector<T extends AbstractLeafletVe
 	protected O createOptions() {
 		AbstractLeafletVectorState s = getState();
 		O o = JsonUtils.safeEval(s.vectorStyleJson);
-                
+
+		if (s.nonBubblingEvents != null) {
+			JsArrayString eventsJsArray = JsArrayString.createArray().cast();
+			for (String event : s.nonBubblingEvents) {
+				eventsJsArray.push(event);
+			}
+			o.setNonBubblingEvents(eventsJsArray);
+		}
+
 		if (s.clickable != null) {
 			o.setClickable(s.clickable);
 		}

--- a/src/main/java/org/vaadin/addon/leaflet/shared/AbstractLeafletVectorState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/shared/AbstractLeafletVectorState.java
@@ -5,6 +5,7 @@ public class AbstractLeafletVectorState extends AbstractLeafletComponentState {
     public String vectorStyleJson;
     public Boolean clickable;
     public String pointerEvents;
+    public String[] nonBubblingEvents;
     public String className;
     public String tooltip;
     public TooltipState tooltipState;

--- a/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/ContextClickOnMap.java
+++ b/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/ContextClickOnMap.java
@@ -55,6 +55,9 @@ public class ContextClickOnMap extends AbstractTest {
             }
         });
 
+        //prevent bubbling of events to DOM parents(like the map)
+        polygon.setNonBubblingEvents(new String[]{"click", "contextmenu"});
+
         leafletMap.addContextMenuListener(new LeafletContextMenuListener() {
             @Override
             public void onContextMenu(LeafletContextMenuEvent event) {


### PR DESCRIPTION
Allow possibility to prevent the events fired on vectors to be propagated to parent DOM elements, like the Map.