### PR TITLE
update to geotools 16.3 and fix maven build g-leaflet dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <vaadin.version>7.7.3</vaadin.version>
-        <geotools.version>10.2</geotools.version>
+        <geotools.version>16.3</geotools.version>
     </properties>
 
     <organization>
@@ -311,7 +311,7 @@
         <dependency>
             <groupId>org.peimari</groupId>
             <artifactId>g-leaflet</artifactId>
-            <version>1.0.4-SNAPSHOT</version>
+            <version>1.0.4</version>
             <!-- Only needed during widgetset compilation, so provided scope would 
             be great for this, but with it is left out from widgetset compilation by 
             vaadin plugin -->


### PR DESCRIPTION
vaadin maven repo does not contain g-leaflet 1.0.4-snapshot.
Geotools 16.3 fixes lots of bugs in various places.
needs testing