### PR TITLE
make LRectangle.getGeometry return correct type

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/LRectangle.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LRectangle.java
@@ -35,9 +35,4 @@ public class LRectangle extends LPolygon {
     protected LeafletRectangleState getState() {
         return (LeafletRectangleState) super.getState();
     }
-
-    @Override
-    public Geometry getGeometry() {
-        return JTSUtil.toLinearRing(this);
-    }
 }


### PR DESCRIPTION
LDrawRectangle returns a LPolygon. getGeometry for that then returns a JTS Rectangle. 
It would not make sense to return a linearRing here and thus have incompatible behavior.

Example use-case:  you create a LDrawRectangle from a custom menu button. The user draws the object, you save that as Geometry somewhere. The user opens contextmenu for that geometry and selects "Edit". User finishes editing and now the geometry which previously was a Polygon suddenly is a LinearLing.

fyi, there is a (jts)Geometry.isRectangle function which allows for easy checking if a polygon is a rectangle and thus can be used for creating a new LRectangle(JtsUtils.getBounds)