### PR TITLE
Treat jtsPolyLine as linestring instead of as polygon

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/LPolygon.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LPolygon.java
@@ -26,10 +26,6 @@ public class LPolygon extends AbstractLeafletVector {
         setPoints(points);
     }
 
-    public LPolygon(LinearRing jtsLinearRing) {
-        this(JTSUtil.toLeafletPointArray(jtsLinearRing));
-    }
-
     public LPolygon(Polygon polygon) {
         setGeometry(polygon);
     }

--- a/src/main/java/org/vaadin/addon/leaflet/LPolyline.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LPolyline.java
@@ -50,7 +50,12 @@ public class LPolyline extends AbstractLeafletVector {
 
     @Override
     public Geometry getGeometry() {
-        return JTSUtil.toLineString(this);
+        final LineString line = JTSUtil.toLineString(this);
+        if(line.isSimple() && line.isClosed())
+        {
+          return JTSUtil.toLinearRing(this);
+        }
+        return line;
     }
 
     public void setGeometry(LineString lineString) {

--- a/src/main/java/org/vaadin/addon/leaflet/util/JTSUtil.java
+++ b/src/main/java/org/vaadin/addon/leaflet/util/JTSUtil.java
@@ -215,8 +215,8 @@ public class JTSUtil {
         return toLineString(points);
     }
 
-    public static LinearRing toLinearRing(LPolygon polygon) {
-        Point[] points = polygon.getPoints();
+    public static LinearRing toLinearRing(LPolyline polyline) {
+        Point[] points = polyline.getPoints();
         if(points.length == 0) {
             return null;
         }


### PR DESCRIPTION
In JTS the class LinearRing extends LineString, but in v-leaflet any LinearRing will be converted to a Polygon and JTSUtil.toLinearRing only accepts LPolygon. I don't see any reasons why the mapping should be done differently in v-leaflet then it is done in JTS.