### PR TITLE
Fix tooltip stylemethods

### DIFF
--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletPopupConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletPopupConnector.java
@@ -2,6 +2,7 @@ package org.vaadin.addon.leaflet.client;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.vaadin.shared.ui.ComponentStateUtil;
 import org.peimari.gleaflet.client.*;
 import org.vaadin.addon.leaflet.shared.LeafletPopupState;
 import org.vaadin.addon.leaflet.shared.PopupServerRpc;
@@ -111,7 +112,7 @@ public class LeafletPopupConnector extends
         popupOptions.setAutoClose(popupState.autoClose);
         popupOptions.setKeepInView(popupState.keepInView);
         String stylename = c.getState().primaryStyleName;
-        if(c.getState().styles != null && !c.getState().styles.isEmpty()) {
+        if(ComponentStateUtil.hasStyles(c.getState())) {
             for(String s : c.getState().styles)
             stylename += " " + s; 
         }

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletPopupConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletPopupConnector.java
@@ -2,7 +2,6 @@ package org.vaadin.addon.leaflet.client;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
-import com.vaadin.shared.ui.ComponentStateUtil;
 import org.peimari.gleaflet.client.*;
 import org.vaadin.addon.leaflet.shared.LeafletPopupState;
 import org.vaadin.addon.leaflet.shared.PopupServerRpc;
@@ -111,12 +110,8 @@ public class LeafletPopupConnector extends
         popupOptions.setCloseOnClick(popupState.closeOnClick);
         popupOptions.setAutoClose(popupState.autoClose);
         popupOptions.setKeepInView(popupState.keepInView);
-        String stylename = c.getState().primaryStyleName;
-        if(ComponentStateUtil.hasStyles(c.getState())) {
-            for(String s : c.getState().styles)
-            stylename += " " + s; 
-        }
-        popupOptions.setClassName(stylename);
+        String styleName = StyleUtil.getStyleNameFromComponentState(c.getState());
+        popupOptions.setClassName(styleName);
         if (popupState.offset != null) {
             popupOptions.setOffset(Point.create(popupState.offset.getLat(),
                     popupState.offset.getLon()));

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletTooltipConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletTooltipConnector.java
@@ -6,6 +6,7 @@ import com.vaadin.client.ServerConnector;
 import com.vaadin.client.VConsole;
 import com.vaadin.client.communication.StateChangeEvent;
 import com.vaadin.client.ui.AbstractComponentConnector;
+import com.vaadin.shared.ui.ComponentStateUtil;
 import com.vaadin.shared.ui.Connect;
 import org.peimari.gleaflet.client.*;
 import org.vaadin.addon.leaflet.shared.LeafletTooltipState;
@@ -88,6 +89,12 @@ public class LeafletTooltipConnector extends AbstractComponentConnector {
         if (tooltipState.opacity != null) {
             tooltipOptions.setOpacity(tooltipState.opacity);
         }
+        String stylename = c.getState().primaryStyleName;
+        if(ComponentStateUtil.hasStyles(c.getState())) {
+            for(String s : c.getState().styles)
+                stylename += " " + s;
+        }
+        tooltipOptions.setClassName(stylename);
         return tooltipOptions;
     }
 

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletTooltipConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletTooltipConnector.java
@@ -6,7 +6,6 @@ import com.vaadin.client.ServerConnector;
 import com.vaadin.client.VConsole;
 import com.vaadin.client.communication.StateChangeEvent;
 import com.vaadin.client.ui.AbstractComponentConnector;
-import com.vaadin.shared.ui.ComponentStateUtil;
 import com.vaadin.shared.ui.Connect;
 import org.peimari.gleaflet.client.*;
 import org.vaadin.addon.leaflet.shared.LeafletTooltipState;
@@ -89,11 +88,7 @@ public class LeafletTooltipConnector extends AbstractComponentConnector {
         if (tooltipState.opacity != null) {
             tooltipOptions.setOpacity(tooltipState.opacity);
         }
-        String stylename = c.getState().primaryStyleName;
-        if(ComponentStateUtil.hasStyles(c.getState())) {
-            for(String s : c.getState().styles)
-                stylename += " " + s;
-        }
+        String stylename = StyleUtil.getStyleNameFromComponentState(c.getState());
         tooltipOptions.setClassName(stylename);
         return tooltipOptions;
     }

--- a/src/main/java/org/vaadin/addon/leaflet/client/StyleUtil.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/StyleUtil.java
@@ -1,0 +1,29 @@
+package org.vaadin.addon.leaflet.client;
+
+import com.vaadin.shared.AbstractComponentState;
+import com.vaadin.shared.ui.ComponentStateUtil;
+
+final class StyleUtil {
+    private StyleUtil(){}
+
+    /**
+     * Retrieves the primaryStyleName and other styles that are set in the componentState and composes them to
+     * one string where each className is separated by an empty space " ".
+     * Checks whether values are set or not.
+     */
+    static String getStyleNameFromComponentState(AbstractComponentState componentState) {
+        StringBuilder styleNameBuilder = new StringBuilder();
+        if (componentState.primaryStyleName != null)
+            styleNameBuilder.append(componentState.primaryStyleName);
+
+        if(ComponentStateUtil.hasStyles(componentState)) {
+            for (String s : componentState.styles) {
+                if (styleNameBuilder.length() > 0)
+                    styleNameBuilder.append(" ");
+
+                styleNameBuilder.append(s);
+            }
+        }
+        return styleNameBuilder.toString();
+    }
+}

--- a/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/PopupTest.java
+++ b/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/PopupTest.java
@@ -1,5 +1,6 @@
 package org.vaadin.addon.leaflet.demoandtestapp;
 
+import com.vaadin.annotations.StyleSheet;
 import com.vaadin.server.ClientConnector.DetachEvent;
 import java.util.LinkedList;
 import java.util.List;
@@ -22,6 +23,7 @@ import org.vaadin.addon.leaflet.LeafletClickListener;
 import org.vaadin.addon.leaflet.shared.PopupState;
 import org.vaadin.addonhelpers.AbstractTest;
 
+@StyleSheet({"testStyles.css"})
 public class PopupTest extends AbstractTest implements DetachListener {
 
 	private LMarker lMarker;
@@ -74,6 +76,10 @@ public class PopupTest extends AbstractTest implements DetachListener {
         popupState2.maxHeight = 30;
         lPopup2.setPopupState(popupState2);
         leafletMap.addComponent(lPopup2);
+
+        LPopup lPopup3 = new LPopup(60.4560, 22.310).setContent("Hi, i've got a custom style in magenta!");
+        lPopup3.setStyleName("popup-custom-style-test");
+        leafletMap.addComponent(lPopup3);
 
         lPopup.addClickListener(new LeafletClickListener() {
             @Override

--- a/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/TooltipTest.java
+++ b/src/test/java/org/vaadin/addon/leaflet/demoandtestapp/TooltipTest.java
@@ -1,11 +1,13 @@
 package org.vaadin.addon.leaflet.demoandtestapp;
 
+import com.vaadin.annotations.StyleSheet;
 import com.vaadin.ui.Component;
 import org.vaadin.addon.leaflet.*;
 import org.vaadin.addon.leaflet.shared.Point;
 import org.vaadin.addon.leaflet.shared.TooltipState;
 import org.vaadin.addonhelpers.AbstractTest;
 
+@StyleSheet({"testStyles.css"})
 public class TooltipTest extends AbstractTest {
 
     @Override
@@ -25,7 +27,8 @@ public class TooltipTest extends AbstractTest {
         leafletMap.setCenter(60.4525, 22.301);
         leafletMap.setZoomLevel(15);
 
-        LTooltip tooltip1 = new LTooltip(60.4540, 22.275).setContent("Hi, I'm a standalone tooltip!");
+        LTooltip tooltip1 = new LTooltip(60.4540, 22.275).setContent("Hi, I'm a standalone tooltip in magenta!");
+        tooltip1.setPrimaryStyleName("tooltip-custom-style-test");
         leafletMap.addComponent(tooltip1);
 
         LMarker marker1 = new LMarker(60.4720, 22.271);

--- a/src/test/resources/org/vaadin/addon/leaflet/demoandtestapp/testStyles.css
+++ b/src/test/resources/org/vaadin/addon/leaflet/demoandtestapp/testStyles.css
@@ -1,7 +1,6 @@
-.tooltip-custom-style-test {
-  /*important because the leaflet-tooltip class has already these property definitions*/
-  color           : #ffffff !important;
-  background-color: #ff00ff !important;
+.leaflet-pane .tooltip-custom-style-test {
+  color           : #ffffff;
+  background-color: #ff00ff;
 }
 .popup-custom-style-test .leaflet-popup-tip,
 .popup-custom-style-test .leaflet-popup-content-wrapper {

--- a/src/test/resources/org/vaadin/addon/leaflet/demoandtestapp/testStyles.css
+++ b/src/test/resources/org/vaadin/addon/leaflet/demoandtestapp/testStyles.css
@@ -1,0 +1,10 @@
+.tooltip-custom-style-test {
+  /*important because the leaflet-tooltip class has already these property definitions*/
+  color           : #ffffff !important;
+  background-color: #ff00ff !important;
+}
+.popup-custom-style-test .leaflet-popup-tip,
+.popup-custom-style-test .leaflet-popup-content-wrapper {
+  color           : #ffffff;
+  background-color: #ff00ff;
+}


### PR DESCRIPTION
When a style (className) has been set (e.g. with _setStyle_) the style was not applied to tooltips. 
I added the passing of the style to the tooltip and modified the popup so that it's done the same way for both.

Also added for both cases an example to the _demoandtestapp_.