### PR TITLE
#231 initial implementation for enabling wms layers with authorization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version>7.7.9</vaadin.version>
+        <vaadin.version>7.7.17</vaadin.version>
         <geotools.version>20.2</geotools.version>
     </properties>
 
     <organization>
         <name>Vaadin Community</name>
-        <url>http://vaadin.com/forum/</url>
+        <url>https://vaadin.com/forum/</url>
     </organization>
 
     <scm>
@@ -33,7 +33,7 @@
     <licenses>
         <license>
             <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
             <comments>A business-friendly OSS license</comments>
         </license>
@@ -301,7 +301,7 @@
         <dependency>
             <groupId>org.peimari</groupId>
             <artifactId>g-leaflet</artifactId>
-            <version>1.0.16</version>
+            <version>1.0.19</version>
             <!-- Only needed during widgetset compilation, so provided scope would 
             be great for this, but with it is left out from widgetset compilation by 
             vaadin plugin -->
@@ -382,7 +382,6 @@
             <version>4.10</version>
             <scope>test</scope>
         </dependency>
-        
 
     </dependencies>
 

--- a/src/main/java/org/vaadin/addon/leaflet/LGridLayer.java
+++ b/src/main/java/org/vaadin/addon/leaflet/LGridLayer.java
@@ -90,6 +90,14 @@ public class LGridLayer extends AbstractLeafletLayer {
     public Bounds getBounds() {
         return getState().bounds;
     }
+    
+    public String getAuthToken() {
+        return getState().authToken;
+    }
+
+    public void setAuthToken(String authToken) {
+        getState().authToken = authToken;
+    }
 
     @Override
     public Geometry getGeometry() {

--- a/src/main/java/org/vaadin/addon/leaflet/client/LeafletWmsLayerConnector.java
+++ b/src/main/java/org/vaadin/addon/leaflet/client/LeafletWmsLayerConnector.java
@@ -42,7 +42,10 @@ public class LeafletWmsLayerConnector extends LeafletTileLayerConnector {
 	
 	@Override
 	protected WmsLayer createGridLayer(GridLayerOptions o) {
-		return WmsLayer.create(getState().url, (WmsLayerOptions ) o);
+		if (getState().authToken != null) {
+			return WmsLayer.create(getState().url, getState().authToken, getState().layers, (WmsLayerOptions ) o, getMap());
+		}
+		return WmsLayer.create(getState().url, (WmsLayerOptions ) o);		
 	}
 
 }

--- a/src/main/java/org/vaadin/addon/leaflet/shared/LeafletGridLayerState.java
+++ b/src/main/java/org/vaadin/addon/leaflet/shared/LeafletGridLayerState.java
@@ -10,4 +10,5 @@ public class LeafletGridLayerState extends AbstractLeafletComponentState {
     public Integer minNativeZoom;
     public Boolean noWrap;
     public String attributionString;
+    public String authToken;
 }


### PR DESCRIPTION
* Use the (upcoming) 1.0.19 version of g-leaflet
* add possibility to set token into shared state
* if the token is set, use appropriate g-leaflet's WmsLayer API